### PR TITLE
Fix iOS version for simulator

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ test:
         CODE_SIGN_IDENTITY=
         PROVISIONING_PROFILE= 
           -sdk iphonesimulator
-          -destination 'platform=iOS Simulator,OS=11.0,name=iPhone 7'
+          -destination 'platform=iOS Simulator,OS=11.0.1,name=iPhone 7'
           -workspace DrawerKit.xcworkspace 
           -scheme "DrawerKitDemo"
       clean build test


### PR DESCRIPTION
Between a branch build and the merge the version available for the simulator seems to have changed. This updates the yml file to reflect this