### PR TITLE
New features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# DrawerKit
+
+## v. 0.2.0
+
+Release 0.2.0 breaks backward compatibility with the earlier release, since one of the protocols has disappeared and a new one has been added. Specific changes and new features are as follows:
+
+- The presenting view controller is no longer required to conform to `DrawerPresenting`. In fact, `DrawerPresenting` no longer exists. Instead, a new protocol was created to take its place, `DrawerCoordinating`, so that *any* object can conform to it and be responsible for vending the drawer display controller. Of course, the presenting view controller can still fulfil that responsibility but it no longer must do so.
+
+- Added **tap-to-expand**. Now, if the corresponding configuration boolean is turned on, tapping on the drawer when it's in its partially expanded state will trigger it to transition to its fully expanded state.
+
+## v. 0.1.1
+
+- Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Release 0.2.0 breaks backward compatibility with the earlier release, since one 
 
 - Added **tap-to-expand**. Now, if the corresponding configuration boolean is turned on, tapping on the drawer when it's in its partially expanded state will trigger it to transition to its fully expanded state.
 
+- Added some under-the-hood improvements in preparation for adding upcoming new features.
+
 ## v. 0.1.1
 
 - Initial release

--- a/DrawerKit.podspec
+++ b/DrawerKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name          = "DrawerKit"
-  s.version       = "0.1.1"
+  s.version       = "0.2.0"
   s.summary       = "An implementation of an interactive and animated view, similar to what you see in Apple Maps"
 
   s.description   = <<-DESC

--- a/DrawerKit/DrawerKit.xcodeproj/project.pbxproj
+++ b/DrawerKit/DrawerKit.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		CB2CB7AA1F8E9AC600AA152D /* DrawerConfiguration+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2CB7A61F8E98F100AA152D /* DrawerConfiguration+Equatable.swift */; };
 		CB2CB7AD1F8E9D9900AA152D /* DrawerDisplayController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2CB7AC1F8E9D9900AA152D /* DrawerDisplayController+Extensions.swift */; };
 		CB2CB7AF1F8E9F4C00AA152D /* DrawerDisplayController+Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2CB7AE1F8E9F4C00AA152D /* DrawerDisplayController+Configuration.swift */; };
+		CB5AF7FC1F9B834E000B2DC9 /* DrawerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5AF7FB1F9B834E000B2DC9 /* DrawerState.swift */; };
 		CB619CEC1F8FFBAD0076E1DE /* InteractionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB619CEB1F8FFBAD0076E1DE /* InteractionController.swift */; };
 		CB9101C61F8F791A000EAC41 /* PresentationController+Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB9101C51F8F791A000EAC41 /* PresentationController+Configuration.swift */; };
 		CBBA2D5C1F8E815B00E0137F /* DrawerKit.h in Headers */ = {isa = PBXBuildFile; fileRef = CBBA2D5A1F8E815B00E0137F /* DrawerKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -31,6 +32,7 @@
 		CB2CB7A61F8E98F100AA152D /* DrawerConfiguration+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DrawerConfiguration+Equatable.swift"; sourceTree = "<group>"; };
 		CB2CB7AC1F8E9D9900AA152D /* DrawerDisplayController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DrawerDisplayController+Extensions.swift"; sourceTree = "<group>"; };
 		CB2CB7AE1F8E9F4C00AA152D /* DrawerDisplayController+Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DrawerDisplayController+Configuration.swift"; sourceTree = "<group>"; };
+		CB5AF7FB1F9B834E000B2DC9 /* DrawerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerState.swift; sourceTree = "<group>"; };
 		CB619CEB1F8FFBAD0076E1DE /* InteractionController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InteractionController.swift; sourceTree = "<group>"; };
 		CB9101C51F8F791A000EAC41 /* PresentationController+Configuration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PresentationController+Configuration.swift"; sourceTree = "<group>"; };
 		CBBA2D571F8E815B00E0137F /* DrawerKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DrawerKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -64,6 +66,7 @@
 		CB2CB7A11F8E963000AA152D /* Internal API */ = {
 			isa = PBXGroup;
 			children = (
+				CB5AF7FB1F9B834E000B2DC9 /* DrawerState.swift */,
 				CB2CB79B1F8E951900AA152D /* PresentationController.swift */,
 				CB619CEB1F8FFBAD0076E1DE /* InteractionController.swift */,
 				CB2CB79C1F8E951900AA152D /* AnimationController.swift */,
@@ -195,6 +198,7 @@
 				CB2CB79F1F8E951900AA152D /* AnimationController.swift in Sources */,
 				CB2CB7951F8E934500AA152D /* DrawerPresenting.swift in Sources */,
 				CB2CB7AF1F8E9F4C00AA152D /* DrawerDisplayController+Configuration.swift in Sources */,
+				CB5AF7FC1F9B834E000B2DC9 /* DrawerState.swift in Sources */,
 				CB2CB7971F8E934500AA152D /* DrawerConfiguration.swift in Sources */,
 				CB2CB7AA1F8E9AC600AA152D /* DrawerConfiguration+Equatable.swift in Sources */,
 				CB2CB79D1F8E951900AA152D /* DrawerDisplayController.swift in Sources */,

--- a/DrawerKit/DrawerKit.xcodeproj/project.pbxproj
+++ b/DrawerKit/DrawerKit.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		CB2CB7941F8E934500AA152D /* DrawerPresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2CB78D1F8E934500AA152D /* DrawerPresentable.swift */; };
-		CB2CB7951F8E934500AA152D /* DrawerPresenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2CB78E1F8E934500AA152D /* DrawerPresenting.swift */; };
+		CB2CB7951F8E934500AA152D /* DrawerCoordinating.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2CB78E1F8E934500AA152D /* DrawerCoordinating.swift */; };
 		CB2CB7971F8E934500AA152D /* DrawerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2CB7911F8E934500AA152D /* DrawerConfiguration.swift */; };
 		CB2CB79D1F8E951900AA152D /* DrawerDisplayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2CB79A1F8E951900AA152D /* DrawerDisplayController.swift */; };
 		CB2CB79E1F8E951900AA152D /* PresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2CB79B1F8E951900AA152D /* PresentationController.swift */; };
@@ -24,7 +24,7 @@
 
 /* Begin PBXFileReference section */
 		CB2CB78D1F8E934500AA152D /* DrawerPresentable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DrawerPresentable.swift; sourceTree = "<group>"; };
-		CB2CB78E1F8E934500AA152D /* DrawerPresenting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DrawerPresenting.swift; sourceTree = "<group>"; };
+		CB2CB78E1F8E934500AA152D /* DrawerCoordinating.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DrawerCoordinating.swift; sourceTree = "<group>"; };
 		CB2CB7911F8E934500AA152D /* DrawerConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DrawerConfiguration.swift; sourceTree = "<group>"; };
 		CB2CB79A1F8E951900AA152D /* DrawerDisplayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerDisplayController.swift; sourceTree = "<group>"; };
 		CB2CB79B1F8E951900AA152D /* PresentationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationController.swift; sourceTree = "<group>"; };
@@ -54,7 +54,7 @@
 		CB2CB7A01F8E962100AA152D /* Public API */ = {
 			isa = PBXGroup;
 			children = (
-				CB2CB78E1F8E934500AA152D /* DrawerPresenting.swift */,
+				CB2CB78E1F8E934500AA152D /* DrawerCoordinating.swift */,
 				CB2CB78D1F8E934500AA152D /* DrawerPresentable.swift */,
 				CB2CB79A1F8E951900AA152D /* DrawerDisplayController.swift */,
 				CB2CB7AE1F8E9F4C00AA152D /* DrawerDisplayController+Configuration.swift */,
@@ -66,10 +66,10 @@
 		CB2CB7A11F8E963000AA152D /* Internal API */ = {
 			isa = PBXGroup;
 			children = (
-				CB5AF7FB1F9B834E000B2DC9 /* DrawerState.swift */,
 				CB2CB79B1F8E951900AA152D /* PresentationController.swift */,
 				CB619CEB1F8FFBAD0076E1DE /* InteractionController.swift */,
 				CB2CB79C1F8E951900AA152D /* AnimationController.swift */,
+				CB5AF7FB1F9B834E000B2DC9 /* DrawerState.swift */,
 				CB2CB7A41F8E98F100AA152D /* Extensions */,
 			);
 			path = "Internal API";
@@ -196,7 +196,7 @@
 				CB619CEC1F8FFBAD0076E1DE /* InteractionController.swift in Sources */,
 				CB2CB7AD1F8E9D9900AA152D /* DrawerDisplayController+Extensions.swift in Sources */,
 				CB2CB79F1F8E951900AA152D /* AnimationController.swift in Sources */,
-				CB2CB7951F8E934500AA152D /* DrawerPresenting.swift in Sources */,
+				CB2CB7951F8E934500AA152D /* DrawerCoordinating.swift in Sources */,
 				CB2CB7AF1F8E9F4C00AA152D /* DrawerDisplayController+Configuration.swift in Sources */,
 				CB5AF7FC1F9B834E000B2DC9 /* DrawerState.swift in Sources */,
 				CB2CB7971F8E934500AA152D /* DrawerConfiguration.swift in Sources */,

--- a/DrawerKit/DrawerKit/Internal API/DrawerState.swift
+++ b/DrawerKit/DrawerKit/Internal API/DrawerState.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+enum DrawerState: Equatable {
+    case collapsed
+    case partiallyExpanded
+    case fullyExpanded
+    case transitioning(CGFloat) // current drawer Y position
+}

--- a/DrawerKit/DrawerKit/Internal API/Extensions/DrawerConfiguration+Equatable.swift
+++ b/DrawerKit/DrawerKit/Internal API/Extensions/DrawerConfiguration+Equatable.swift
@@ -7,6 +7,8 @@ extension DrawerConfiguration {
             && lhs.supportsPartialExpansion == rhs.supportsPartialExpansion
             && lhs.dismissesInStages == rhs.dismissesInStages
             && lhs.isDrawerDraggable == rhs.isDrawerDraggable
+            && lhs.isFullyPresentableByDrawerTaps == rhs.isFullyPresentableByDrawerTaps
+            && lhs.numberOfTapsForFullDrawerPresentation == rhs.numberOfTapsForFullDrawerPresentation
             && lhs.isDismissableByOutsideDrawerTaps == rhs.isDismissableByOutsideDrawerTaps
             && lhs.numberOfTapsForOutsideDrawerDismissal == rhs.numberOfTapsForOutsideDrawerDismissal
             && lhs.flickSpeedThreshold == rhs.flickSpeedThreshold

--- a/DrawerKit/DrawerKit/Internal API/Extensions/PresentationController+Configuration.swift
+++ b/DrawerKit/DrawerKit/Internal API/Extensions/PresentationController+Configuration.swift
@@ -37,6 +37,14 @@ extension PresentationController {
         return configuration.isDrawerDraggable
     }
 
+    var isFullyPresentableByDrawerTaps: Bool {
+        return configuration.isFullyPresentableByDrawerTaps
+    }
+
+    var numberOfTapsForFullDrawerPresentation: Int {
+        return configuration.numberOfTapsForFullDrawerPresentation
+    }
+
     var isDismissableByOutsideDrawerTaps: Bool {
         return configuration.isDismissableByOutsideDrawerTaps
     }

--- a/DrawerKit/DrawerKit/Internal API/InteractionController.swift
+++ b/DrawerKit/DrawerKit/Internal API/InteractionController.swift
@@ -4,7 +4,7 @@ final class InteractionController: UIPercentDrivenInteractiveTransition {
     private let isPresentation: Bool
     private weak var presentingVC: UIViewController!
     private weak var presentedVC: UIViewController!
-    private var presentedViewDragGR: UIPanGestureRecognizer?
+    private var drawerDragGR: UIPanGestureRecognizer?
     private var containerH: CGFloat = 0
 
     init(isPresentation: Bool, presentingVC: UIViewController, presentedVC: UIViewController) {
@@ -26,22 +26,22 @@ extension InteractionController {
 
 private extension InteractionController {
     func setupPresentedViewDragRecogniser() {
-        guard presentedViewDragGR == nil else { return }
+        guard drawerDragGR == nil else { return }
         let panGesture = UIPanGestureRecognizer(target: self,
                                                 action: #selector(handlePresentedViewDrag))
         presentedVC.view.addGestureRecognizer(panGesture)
-        presentedViewDragGR = panGesture
+        drawerDragGR = panGesture
     }
 
     func removePresentedViewDragRecogniser() {
-        guard let panGesture = presentedViewDragGR else { return }
+        guard let panGesture = drawerDragGR else { return }
         presentedVC.view.removeGestureRecognizer(panGesture)
-        presentedViewDragGR = nil
+        drawerDragGR = nil
     }
 
     @objc func handlePresentedViewDrag() {
         guard
-            let panGesture = presentedViewDragGR,
+            let panGesture = drawerDragGR,
             let view = panGesture.view
             else { return }
 

--- a/DrawerKit/DrawerKit/Internal API/InteractionController.swift
+++ b/DrawerKit/DrawerKit/Internal API/InteractionController.swift
@@ -12,7 +12,7 @@ final class InteractionController: UIPercentDrivenInteractiveTransition {
         self.presentingVC = presentingVC
         self.presentedVC = presentedVC
         super.init()
-        setupPresentedViewDragRecogniser()
+        setupDrawerDragRecogniser()
         wantsInteractiveStart = false
     }
 }
@@ -25,21 +25,21 @@ extension InteractionController {
 }
 
 private extension InteractionController {
-    func setupPresentedViewDragRecogniser() {
+    func setupDrawerDragRecogniser() {
         guard drawerDragGR == nil else { return }
         let panGesture = UIPanGestureRecognizer(target: self,
-                                                action: #selector(handlePresentedViewDrag))
+                                                action: #selector(handleDrawerDrag))
         presentedVC.view.addGestureRecognizer(panGesture)
         drawerDragGR = panGesture
     }
 
-    func removePresentedViewDragRecogniser() {
+    func removeDrawerDragRecogniser() {
         guard let panGesture = drawerDragGR else { return }
         presentedVC.view.removeGestureRecognizer(panGesture)
         drawerDragGR = nil
     }
 
-    @objc func handlePresentedViewDrag() {
+    @objc func handleDrawerDrag() {
         guard
             let panGesture = drawerDragGR,
             let view = panGesture.view

--- a/DrawerKit/DrawerKit/Internal API/PresentationController.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController.swift
@@ -154,8 +154,10 @@ private extension PresentationController {
     }
 
     func cornerRadius(at state: DrawerState) -> CGFloat {
-        guard maximumCornerRadius != 0 && drawerPartialY != 0
-            && drawerPartialY != containerViewH else { return 0 }
+        guard maximumCornerRadius != 0
+            && drawerPartialY != 0
+            && drawerPartialY != containerViewH
+            else { return 0 }
 
         let positionY = drawerPositionY(for: state)
 

--- a/DrawerKit/DrawerKit/Internal API/PresentationController.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController.swift
@@ -3,8 +3,8 @@ import UIKit
 final class PresentationController: UIPresentationController {
     let configuration: DrawerConfiguration // intentionally internal and immutable
     private var lastDrawerY: CGFloat = 0
-    private var containerViewDismissalTapGR: UITapGestureRecognizer?
-    private var presentedViewDragGR: UIPanGestureRecognizer?
+    private var drawerDismissalTapGR: UITapGestureRecognizer?
+    private var drawerDragGR: UIPanGestureRecognizer?
     private let inDebugMode: Bool
 
     init(presentingVC: UIViewController?,
@@ -28,7 +28,7 @@ extension PresentationController {
 
     override func presentationTransitionWillBegin() {
         containerView?.backgroundColor = .clear
-        setupContainerViewDismissalTapRecogniser()
+        setupDrawerDismissalTapRecogniser()
         setupPresentedViewDragRecogniser()
         setupDebugHeightMarks()
         addCornerRadiusAnimationEnding(at: drawerPartialY)
@@ -39,7 +39,7 @@ extension PresentationController {
     }
 
     override func dismissalTransitionDidEnd(_ completed: Bool) {
-        removeContainerViewDismissalTapRecogniser()
+        removeDrawerDismissalTapRecogniser()
         removePresentedViewDragRecogniser()
     }
 
@@ -94,27 +94,27 @@ private extension PresentationController {
 }
 
 private extension PresentationController {
-    func setupContainerViewDismissalTapRecogniser() {
-        guard containerViewDismissalTapGR == nil else { return }
+    func setupDrawerDismissalTapRecogniser() {
+        guard drawerDismissalTapGR == nil else { return }
         let isDismissable = isDismissableByOutsideDrawerTaps
         let numTapsRequired = numberOfTapsForOutsideDrawerDismissal
         guard isDismissable && numTapsRequired > 0 else { return }
         let tapGesture = UITapGestureRecognizer(target: self,
-                                                action: #selector(handleContainerViewDismissalTap))
+                                                action: #selector(handleDrawerDismissalTap))
         tapGesture.numberOfTouchesRequired = 1
         tapGesture.numberOfTapsRequired = numTapsRequired
         containerView?.addGestureRecognizer(tapGesture)
-        containerViewDismissalTapGR = tapGesture
+        drawerDismissalTapGR = tapGesture
     }
 
-    func removeContainerViewDismissalTapRecogniser() {
-        guard let tapGesture = containerViewDismissalTapGR else { return }
+    func removeDrawerDismissalTapRecogniser() {
+        guard let tapGesture = drawerDismissalTapGR else { return }
         containerView?.removeGestureRecognizer(tapGesture)
-        containerViewDismissalTapGR = nil
+        drawerDismissalTapGR = nil
     }
 
-    @objc func handleContainerViewDismissalTap() {
-        guard let tapGesture = containerViewDismissalTapGR else { return }
+    @objc func handleDrawerDismissalTap() {
+        guard let tapGesture = drawerDismissalTapGR else { return }
         let tapY = tapGesture.location(in: containerView).y
         guard tapY < currentDrawerY else { return }
         presentedViewController.dismiss(animated: true)
@@ -123,21 +123,21 @@ private extension PresentationController {
 
 private extension PresentationController {
     func setupPresentedViewDragRecogniser() {
-        guard presentedViewDragGR == nil && isDrawerDraggable else { return }
+        guard drawerDragGR == nil && isDrawerDraggable else { return }
         let panGesture = UIPanGestureRecognizer(target: self,
                                                 action: #selector(handlePresentedViewDrag))
         presentedView?.addGestureRecognizer(panGesture)
-        presentedViewDragGR = panGesture
+        drawerDragGR = panGesture
     }
 
     func removePresentedViewDragRecogniser() {
-        guard let panGesture = presentedViewDragGR else { return }
+        guard let panGesture = drawerDragGR else { return }
         presentedView?.removeGestureRecognizer(panGesture)
-        presentedViewDragGR = nil
+        drawerDragGR = nil
     }
 
     @objc func handlePresentedViewDrag() {
-        guard let panGesture = presentedViewDragGR, let view = panGesture.view else { return }
+        guard let panGesture = drawerDragGR, let view = panGesture.view else { return }
 
         switch panGesture.state {
         case .began:

--- a/DrawerKit/DrawerKit/Internal API/PresentationController.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController.swift
@@ -31,7 +31,7 @@ extension PresentationController {
         containerView?.backgroundColor = .clear
         setupDrawerFullExpansionTapRecogniser()
         setupDrawerDismissalTapRecogniser()
-        setupPresentedViewDragRecogniser()
+        setupDrawerDragRecogniser()
         setupDebugHeightMarks()
         addCornerRadiusAnimationEnding(at: drawerPartialY)
     }
@@ -43,7 +43,7 @@ extension PresentationController {
     override func dismissalTransitionDidEnd(_ completed: Bool) {
         removeDrawerFullExpansionTapRecogniser()
         removeDrawerDismissalTapRecogniser()
-        removePresentedViewDragRecogniser()
+        removeDrawerDragRecogniser()
     }
 
     override func containerViewWillLayoutSubviews() {
@@ -153,21 +153,21 @@ private extension PresentationController {
 }
 
 private extension PresentationController {
-    func setupPresentedViewDragRecogniser() {
+    func setupDrawerDragRecogniser() {
         guard drawerDragGR == nil && isDrawerDraggable else { return }
         let panGesture = UIPanGestureRecognizer(target: self,
-                                                action: #selector(handlePresentedViewDrag))
+                                                action: #selector(handleDrawerDrag))
         presentedView?.addGestureRecognizer(panGesture)
         drawerDragGR = panGesture
     }
 
-    func removePresentedViewDragRecogniser() {
+    func removeDrawerDragRecogniser() {
         guard let panGesture = drawerDragGR else { return }
         presentedView?.removeGestureRecognizer(panGesture)
         drawerDragGR = nil
     }
 
-    @objc func handlePresentedViewDrag() {
+    @objc func handleDrawerDrag() {
         guard let panGesture = drawerDragGR, let view = panGesture.view else { return }
 
         switch panGesture.state {

--- a/DrawerKit/DrawerKit/Internal API/PresentationController.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController.swift
@@ -321,8 +321,10 @@ private extension PresentationController {
     }
 
     func addCornerRadiusAnimationEnding(at endState: DrawerState) {
-        guard maximumCornerRadius != 0 && drawerPartialY != 0
-            && endState != currentDrawerState else { return }
+        guard maximumCornerRadius != 0
+            && drawerPartialY != 0
+            && endState != currentDrawerState
+            else { return }
 
         let animator = UIViewPropertyAnimator(duration: durationInSeconds,
                                               timingParameters: timingCurveProvider)

--- a/DrawerKit/DrawerKit/Internal API/PresentationController.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController.swift
@@ -62,7 +62,7 @@ private extension PresentationController {
 
     var drawerPartialH: CGFloat {
         guard let presentedVC = presentedViewController as? DrawerPresentable else { return 0 }
-        return max(0, presentedVC.heightOfPartiallyExpandedDrawer)
+        return min(max(presentedVC.heightOfPartiallyExpandedDrawer, 0), containerViewH)
     }
 
     var drawerPartialY: CGFloat {
@@ -70,27 +70,37 @@ private extension PresentationController {
     }
 
     var upperMarkY: CGFloat {
-        return drawerPartialY - upperMarkGap
+        return max(drawerPartialY - upperMarkGap, 0)
     }
 
     var lowerMarkY: CGFloat {
-        return drawerPartialY + lowerMarkGap
+        return min(drawerPartialY + lowerMarkGap, containerViewH)
     }
 
     var currentDrawerY: CGFloat {
-        get { return presentedView?.frame.origin.y ?? 0 }
-        set { presentedView?.frame.origin.y = newValue }
+        get {
+            let posY = presentedView?.frame.origin.y ?? 0
+            return min(max(posY, 0), containerViewH)
+        }
+        set {
+            let posY = min(max(newValue, 0), containerViewH)
+            presentedView?.frame.origin.y = posY
+        }
     }
 
     var currentDrawerCornerRadius: CGFloat {
-        get { return presentedView?.layer.cornerRadius ?? 0 }
+        get {
+            let radius = presentedView?.layer.cornerRadius ?? 0
+            return min(max(radius, 0), maximumCornerRadius)
+        }
         set {
-            presentedView?.layer.cornerRadius = newValue
+            let radius = min(max(newValue, 0), maximumCornerRadius)
+            presentedView?.layer.cornerRadius = radius
             if #available(iOS 11.0, *) {
                 presentedView?.layer.maskedCorners =
                     [.layerMinXMinYCorner, .layerMaxXMinYCorner]
             } else {
-                presentedView?.roundCorners([.topLeft, .topRight], radius: newValue)
+                presentedView?.roundCorners([.topLeft, .topRight], radius: radius)
             }
         }
     }

--- a/DrawerKit/DrawerKit/Public API/DrawerConfiguration.swift
+++ b/DrawerKit/DrawerKit/Public API/DrawerConfiguration.swift
@@ -78,7 +78,6 @@ public struct DrawerConfiguration: Equatable {
     /// corner animations from taking place. The default value is 15 points.
     public var maximumCornerRadius: CGFloat
 
-
     /// Initialiser for `DrawerConfiguration`.
     public init(durationInSeconds: TimeInterval = 0.3,
                 timingCurveProvider: UITimingCurveProvider = UISpringTimingParameters(),

--- a/DrawerKit/DrawerKit/Public API/DrawerConfiguration.swift
+++ b/DrawerKit/DrawerKit/Public API/DrawerConfiguration.swift
@@ -34,6 +34,14 @@ public struct DrawerConfiguration: Equatable {
     /// Whether or not the drawer can be dragged up and down. The default value is `true`.
     public var isDrawerDraggable: Bool
 
+    /// Whether or not the drawer can be fully presentable by tapping on it.
+    /// The default value is `true`.
+    public var isFullyPresentableByDrawerTaps: Bool
+
+    /// How many taps are required for fully presenting the drawer by tapping on it.
+    /// The default value is 1.
+    public var numberOfTapsForFullDrawerPresentation: Int
+
     /// Whether or not the drawer can be dismissed by tapping anywhere outside of it.
     /// The default value is `true`.
     public var isDismissableByOutsideDrawerTaps: Bool
@@ -77,6 +85,8 @@ public struct DrawerConfiguration: Equatable {
                 supportsPartialExpansion: Bool = true,
                 dismissesInStages: Bool = true,
                 isDrawerDraggable: Bool = true,
+                isFullyPresentableByDrawerTaps: Bool = true,
+                numberOfTapsForFullDrawerPresentation: Int = 1,
                 isDismissableByOutsideDrawerTaps: Bool = true,
                 numberOfTapsForOutsideDrawerDismissal: Int = 1,
                 flickSpeedThreshold: CGFloat = 3,
@@ -88,6 +98,8 @@ public struct DrawerConfiguration: Equatable {
         self.supportsPartialExpansion = supportsPartialExpansion
         self.dismissesInStages = dismissesInStages
         self.isDrawerDraggable = isDrawerDraggable
+        self.isFullyPresentableByDrawerTaps = isFullyPresentableByDrawerTaps
+        self.numberOfTapsForFullDrawerPresentation = max(0, numberOfTapsForFullDrawerPresentation)
         self.isDismissableByOutsideDrawerTaps = isDismissableByOutsideDrawerTaps
         self.numberOfTapsForOutsideDrawerDismissal = max(0, numberOfTapsForOutsideDrawerDismissal)
         self.flickSpeedThreshold = max(0, flickSpeedThreshold)

--- a/DrawerKit/DrawerKit/Public API/DrawerCoordinating.swift
+++ b/DrawerKit/DrawerKit/Public API/DrawerCoordinating.swift
@@ -1,0 +1,10 @@
+import UIKit
+
+/// Protocol that objects interested in coordinating drawer presentations must conform to.
+/// Note that view controllers *can* conform to this protocol but *need not* do so. Other
+/// objects can take that responsibility, if that's more convenient.
+public protocol DrawerCoordinating: class {
+    /// An object vended by the conforming object, whose responsibility is to control
+    /// the presentation, animation, and interactivity of/with the drawer.
+    var drawerDisplayController: DrawerDisplayController? { get }
+}

--- a/DrawerKit/DrawerKit/Public API/DrawerDisplayController+Configuration.swift
+++ b/DrawerKit/DrawerKit/Public API/DrawerDisplayController+Configuration.swift
@@ -43,6 +43,18 @@ extension DrawerDisplayController {
         return configuration.isDrawerDraggable
     }
 
+    /// Whether or not the drawer can be fully presentable by tapping on it.
+    /// The default value is `true`.
+    public var isFullyPresentableByDrawerTaps: Bool {
+        return configuration.isFullyPresentableByDrawerTaps
+    }
+
+    /// How many taps are required for fully presenting the drawer by tapping on it.
+    /// The default value is 1.
+    public var numberOfTapsForFullDrawerPresentation: Int {
+        return configuration.numberOfTapsForFullDrawerPresentation
+    }
+
     /// Whether or not the drawer can be dismissed by tapping anywhere outside of it.
     /// The default value is `true`.
     public var isDismissableByOutsideDrawerTaps: Bool {

--- a/DrawerKit/DrawerKit/Public API/DrawerDisplayController.swift
+++ b/DrawerKit/DrawerKit/Public API/DrawerDisplayController.swift
@@ -5,12 +5,13 @@ import UIKit
 // - support insufficiently tall content
 // - support not-covering status bar and/or having a gap at the top
 
-/// Instances of this class are returned as part of the `DrawerPresenting` protocol.
+/// Instances of this class are returned by objects conforming to
+/// the `DrawerCoordinating` protocol.
 public final class DrawerDisplayController: NSObject {
     /// The collection of configurable parameters dictating how the drawer works.
     public let configuration: DrawerConfiguration
 
-    weak var presentingVC: (UIViewController & DrawerPresenting)?
+    weak var presentingVC: UIViewController?
     /* strong */ var presentedVC: (UIViewController & DrawerPresentable)
 
     let inDebugMode: Bool
@@ -28,7 +29,7 @@ public final class DrawerDisplayController: NSObject {
     ///        a boolean value which, when true, draws guiding lines on top of the
     ///        presenting view controller but below the presented view controller.
     ///        Its default value is false.
-    public init(presentingViewController: (UIViewController & DrawerPresenting),
+    public init(presentingViewController: UIViewController,
                 presentedViewController: (UIViewController & DrawerPresentable),
                 configuration: DrawerConfiguration = DrawerConfiguration(),
                 inDebugMode: Bool = false) {

--- a/DrawerKit/DrawerKit/Public API/DrawerPresenting.swift
+++ b/DrawerKit/DrawerKit/Public API/DrawerPresenting.swift
@@ -1,9 +1,0 @@
-import UIKit
-
-/// Protocol that view controllers presenting a drawer must conform to.
-public protocol DrawerPresenting: class {
-    /// An object vended by the presenting view controller, whose responsibility
-    /// is to coordinate the presentation, animation, and interactivity of/with
-    /// the drawer.
-    var drawerDisplayController: DrawerDisplayController? { get }
-}

--- a/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import DrawerKit
 
-class PresenterViewController: UIViewController, DrawerPresenting {
+class PresenterViewController: UIViewController, DrawerCoordinating {
     /* strong */ var drawerDisplayController: DrawerDisplayController?
 
     @IBAction func presentButtonTapped() {

--- a/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
@@ -20,7 +20,7 @@ private extension PresenterViewController {
         // ... or after initialisation. All of these have default values so change only
         // what you need to configure differently. They're all listed here just so you
         // can see what can be configured.
-        configuration.durationInSeconds = 0.8
+        configuration.totalDurationInSeconds = 0.3
         configuration.timingCurveProvider = UISpringTimingParameters(dampingRatio: 0.8)
         configuration.supportsPartialExpansion = true
         configuration.dismissesInStages = true
@@ -30,8 +30,8 @@ private extension PresenterViewController {
         configuration.isDismissableByOutsideDrawerTaps = true
         configuration.numberOfTapsForOutsideDrawerDismissal = 1
         configuration.flickSpeedThreshold = 3
-        configuration.upperMarkGap = 30
-        configuration.lowerMarkGap = 30
+        configuration.upperMarkGap = 100
+        configuration.lowerMarkGap = 80
         configuration.maximumCornerRadius = 20
 
         drawerDisplayController = DrawerDisplayController(presentingViewController: self,

--- a/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
@@ -20,7 +20,7 @@ private extension PresenterViewController {
         // ... or after initialisation. All of these have default values so change only
         // what you need to configure differently. They're all listed here just so you
         // can see what can be configured.
-        configuration.totalDurationInSeconds = 0.3
+        configuration.durationInSeconds = 0.8
         configuration.timingCurveProvider = UISpringTimingParameters(dampingRatio: 0.8)
         configuration.supportsPartialExpansion = true
         configuration.dismissesInStages = true

--- a/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
@@ -17,12 +17,16 @@ private extension PresenterViewController {
         // you can provide the configuration values in the initialiser...
         var configuration = DrawerConfiguration(/* ..., ..., ..., */)
 
-        // ... or after initialisation
+        // ... or after initialisation. All of these have default values so change only
+        // what you need to configure differently. They're all listed here just so you
+        // can see what can be configured.
         configuration.durationInSeconds = 0.8
         configuration.timingCurveProvider = UISpringTimingParameters(dampingRatio: 0.8)
         configuration.supportsPartialExpansion = true
         configuration.dismissesInStages = true
         configuration.isDrawerDraggable = true
+        configuration.isFullyPresentableByDrawerTaps = true
+        configuration.numberOfTapsForFullDrawerPresentation = 1
         configuration.isDismissableByOutsideDrawerTaps = true
         configuration.numberOfTapsForOutsideDrawerDismissal = 1
         configuration.flickSpeedThreshold = 3

--- a/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
@@ -36,7 +36,8 @@ private extension PresenterViewController {
 
         drawerDisplayController = DrawerDisplayController(presentingViewController: self,
                                                           presentedViewController: vc,
-                                                          configuration: configuration)
+                                                          configuration: configuration,
+                                                          inDebugMode: true)
 
         present(vc, animated: true)
     }

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ responsibility but it no longer must do so.
 on the drawer when it's in its partially expanded state will trigger it to transition to its
 fully expanded state.
 
+- Added some under-the-hood improvements in preparation for adding upcoming new features.
+
 ## What version of iOS does it require or support?
 
 __DrawerKit__ is compatible with iOS 10 and above.

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ If you use [Carthage][] to manage your dependencies, simply add
 DrawerKit to your `Cartfile`:
 
 ```
-github "Babylonpartners/DrawerKit" ~> 0.0.1
+github "Babylonpartners/DrawerKit" ~> 1.0
 ```
 
 If you use Carthage to build your dependencies, make sure you have added `DrawerKit.framework`

--- a/README.md
+++ b/README.md
@@ -22,11 +22,23 @@ that limitation.
 	</a>
 </p>
 
+## What's new since v. 0.1.1?
+
+Please note that v. `0.2.0` is not backward-compatible with v. 0.1.1.
+
+- The presenting view controller is no longer required to conform to `DrawerPresenting`. In fact,
+`DrawerPresenting` no longer exists. Instead, a new protocol was created to take its place,
+`DrawerCoordinating`, so that *any* object can conform to it and be responsible for vending the
+drawer display controller. Of course, the presenting view controller can still fulfil that
+responsibility but it no longer must do so.
+
+- Added **tap-to-expand**. Now, if the corresponding configuration boolean is turned on, tapping
+on the drawer when it's in its partially expanded state will trigger it to transition to its
+fully expanded state.
+
 ## What version of iOS does it require or support?
 
 __DrawerKit__ is compatible with iOS 10 and above.
-
-Please note that version 0.12 is not backward-compatible with version 0.1.1. For details, please read the [change log file]().
 
 ## How to use it?
 


### PR DESCRIPTION
This PR adds the following changes:

Release 0.2.0 breaks backward compatibility with the earlier release, since one of the protocols has disappeared and a new one has been added. Specific changes and new features are as follows:

- The presenting view controller is no longer required to conform to `DrawerPresenting`. In fact, `DrawerPresenting` no longer exists. Instead, a new protocol was created to take its place, `DrawerCoordinating`, so that *any* object can conform to it and be responsible for vending the drawer display controller. Of course, the presenting view controller can still fulfil that responsibility but it no longer must do so.

- Added **tap-to-expand**. Now, if the corresponding configuration boolean is turned on, tapping on the drawer when it's in its partially expanded state will trigger it to transition to its fully expanded state.

- Added some under-the-hood improvements in preparation for adding upcoming new features.
