### PR TITLE
DrawerKit release 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # DrawerKit
 
+## v. 0.3.1
+
+- Better support for concurrent animations: in previous versions, the actual presenting view controller wasn't necessarily what you'd think is the presenting view controller, which caused problems when trying to animate its view concurrently with the drawer animation. Now, although it's still the case that the presenting view controller may not be the view controller you think it is, the view controller that you think is the presenting view controller and which you add conformance to `DrawerAnimationParticipant` is the view controller whose animation closures get invoked.
+
+- Notifications: it's now possible to subscribe to notifications indicating when the drawer is tapped (both in its interior and in its exterior), when drawer transitions are about to start, and when they're completed.
+
 ## v. 0.3.0
 
 Release 0.3.0 breaks backwards compatibility with the earlier releases. Specific changes and new features are as follows:

--- a/DrawerKit.podspec
+++ b/DrawerKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name          = "DrawerKit"
-  s.version       = "0.3.0"
+  s.version       = "0.3.1"
   s.summary       = "An implementation of an interactive and animated view, similar to what you see in Apple Maps"
 
   s.description   = <<-DESC

--- a/DrawerKit/DrawerKit.xcodeproj/project.pbxproj
+++ b/DrawerKit/DrawerKit.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		CB2CB79F1F8E951900AA152D /* AnimationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2CB79C1F8E951900AA152D /* AnimationController.swift */; };
 		CB2CB7AD1F8E9D9900AA152D /* DrawerDisplayController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2CB7AC1F8E9D9900AA152D /* DrawerDisplayController+Extensions.swift */; };
 		CB2CB7AF1F8E9F4C00AA152D /* DrawerDisplayController+Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2CB7AE1F8E9F4C00AA152D /* DrawerDisplayController+Configuration.swift */; };
+		CB3CAFBE1FB248B000AD28A1 /* DrawerNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3CAFBD1FB248B000AD28A1 /* DrawerNotifications.swift */; };
+		CB3CAFC01FB24BD800AD28A1 /* Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB3CAFBF1FB24BD800AD28A1 /* Notifications.swift */; };
 		CB5AF7FC1F9B834E000B2DC9 /* DrawerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5AF7FB1F9B834E000B2DC9 /* DrawerState.swift */; };
 		CB5AF8001F9BDAC5000B2DC9 /* DrawerAnimationParticipant.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5AF7FF1F9BDAC5000B2DC9 /* DrawerAnimationParticipant.swift */; };
 		CB5AF8021F9BDF29000B2DC9 /* DrawerAnimationActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB5AF8011F9BDF29000B2DC9 /* DrawerAnimationActions.swift */; };
@@ -44,6 +46,8 @@
 		CB2CB79C1F8E951900AA152D /* AnimationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationController.swift; sourceTree = "<group>"; };
 		CB2CB7AC1F8E9D9900AA152D /* DrawerDisplayController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DrawerDisplayController+Extensions.swift"; sourceTree = "<group>"; };
 		CB2CB7AE1F8E9F4C00AA152D /* DrawerDisplayController+Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DrawerDisplayController+Configuration.swift"; sourceTree = "<group>"; };
+		CB3CAFBD1FB248B000AD28A1 /* DrawerNotifications.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DrawerNotifications.swift; sourceTree = "<group>"; };
+		CB3CAFBF1FB24BD800AD28A1 /* Notifications.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Notifications.swift; sourceTree = "<group>"; };
 		CB5AF7FB1F9B834E000B2DC9 /* DrawerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerState.swift; sourceTree = "<group>"; };
 		CB5AF7FF1F9BDAC5000B2DC9 /* DrawerAnimationParticipant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerAnimationParticipant.swift; sourceTree = "<group>"; };
 		CB5AF8011F9BDF29000B2DC9 /* DrawerAnimationActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerAnimationActions.swift; sourceTree = "<group>"; };
@@ -81,6 +85,8 @@
 			isa = PBXGroup;
 			children = (
 				CB2CB79A1F8E951900AA152D /* DrawerDisplayController.swift */,
+				CB3CAFBD1FB248B000AD28A1 /* DrawerNotifications.swift */,
+				CB3CAFBF1FB24BD800AD28A1 /* Notifications.swift */,
 				CB5AF8071F9BE105000B2DC9 /* Protocols */,
 				CB5AF8081F9BE12E000B2DC9 /* Structs */,
 				CB5AF8121F9BE9B3000B2DC9 /* Extensions */,
@@ -250,6 +256,7 @@
 				CB5AF8061F9BE0E3000B2DC9 /* DrawerGeometry.swift in Sources */,
 				CB5AF8021F9BDF29000B2DC9 /* DrawerAnimationActions.swift in Sources */,
 				CB2CB7941F8E934500AA152D /* DrawerPresentable.swift in Sources */,
+				CB3CAFC01FB24BD800AD28A1 /* Notifications.swift in Sources */,
 				CB5AF8001F9BDAC5000B2DC9 /* DrawerAnimationParticipant.swift in Sources */,
 				CB619CEC1F8FFBAD0076E1DE /* InteractionController.swift in Sources */,
 				CB6F86B81F9C0539000FA37A /* PresentationController+Properties.swift in Sources */,
@@ -265,6 +272,7 @@
 				CB6F86BA1F9C05E6000FA37A /* PresentationController+Gestures.swift in Sources */,
 				CB5AF7FC1F9B834E000B2DC9 /* DrawerState.swift in Sources */,
 				CB2CB7971F8E934500AA152D /* DrawerConfiguration.swift in Sources */,
+				CB3CAFBE1FB248B000AD28A1 /* DrawerNotifications.swift in Sources */,
 				CBFA36F21F9C4004006847BB /* GeometryEvaluator.swift in Sources */,
 				CB6F86B41F9C036D000FA37A /* PresentationController+Utilities.swift in Sources */,
 				CB5AF8141F9BEA91000B2DC9 /* DrawerAnimationInfo+Geometry.swift in Sources */,

--- a/DrawerKit/DrawerKit/Internal API/AnimationController.swift
+++ b/DrawerKit/DrawerKit/Internal API/AnimationController.swift
@@ -4,9 +4,17 @@ final class AnimationController: NSObject {
     private let isPresentation: Bool
     private let configuration: DrawerConfiguration
 
-    init(isPresentation: Bool, configuration: DrawerConfiguration) {
+    let presentingDrawerAnimationActions: DrawerAnimationActions
+    let presentedDrawerAnimationActions: DrawerAnimationActions
+
+    init(isPresentation: Bool,
+         configuration: DrawerConfiguration,
+         presentingDrawerAnimationActions: DrawerAnimationActions,
+         presentedDrawerAnimationActions: DrawerAnimationActions) {
         self.isPresentation = isPresentation
         self.configuration = configuration
+        self.presentingDrawerAnimationActions = presentingDrawerAnimationActions
+        self.presentedDrawerAnimationActions = presentedDrawerAnimationActions
         super.init()
     }
 }
@@ -58,22 +66,25 @@ extension AnimationController: UIViewControllerAnimatedTransitioning {
                                              duration,
                                              isPresentation)
 
-        AnimationSupport.clientPrepareViews(presentingVC: presentingVC,
-                                            presentedVC: presentedVC,
+        let presentingAnimationActions = self.presentingDrawerAnimationActions
+        let presentedAnimationActions = self.presentedDrawerAnimationActions
+
+        AnimationSupport.clientPrepareViews(presentingDrawerAnimationActions: presentingAnimationActions,
+                                            presentedDrawerAnimationActions: presentedAnimationActions,
                                             info)
         presentedVC.view.frame = initialFrame
 
         animator.addAnimations {
             presentedVC.view.frame = finalFrame
-            AnimationSupport.clientAnimateAlong(presentingVC: presentingVC,
-                                                presentedVC: presentedVC,
+            AnimationSupport.clientAnimateAlong(presentingDrawerAnimationActions: presentingAnimationActions,
+                                                presentedDrawerAnimationActions: presentedAnimationActions,
                                                 info)
         }
 
         animator.addCompletion { endingPosition in
             let finished = (endingPosition == UIViewAnimatingPosition.end)
-            AnimationSupport.clientCleanupViews(presentingVC: presentingVC,
-                                                presentedVC: presentedVC,
+            AnimationSupport.clientCleanupViews(presentingDrawerAnimationActions: presentingAnimationActions,
+                                                presentedDrawerAnimationActions: presentedAnimationActions,
                                                 endingPosition,
                                                 info)
             transitionContext.completeTransition(finished)

--- a/DrawerKit/DrawerKit/Internal API/AnimationSupport.swift
+++ b/DrawerKit/DrawerKit/Internal API/AnimationSupport.swift
@@ -49,27 +49,29 @@ struct AnimationSupport {
                                    endPosition: endingPosition)
     }
 
-    static func clientPrepareViews(presentingVC: UIViewController,
-                                   presentedVC: UIViewController,
+    static func clientPrepareViews(presentingDrawerAnimationActions: DrawerAnimationActions,
+                                   presentedDrawerAnimationActions: DrawerAnimationActions,
                                    _ info: DrawerAnimationInfo) {
-        (presentingVC as? DrawerAnimationParticipant)?.drawerAnimationActions.prepare?(info)
-        (presentedVC as? DrawerAnimationParticipant)?.drawerAnimationActions.prepare?(info)
+        NotificationCenter.default.post(notification: DrawerNotification.transitionWillStart(info: info))
+        presentingDrawerAnimationActions.prepare?(info)
+        presentedDrawerAnimationActions.prepare?(info)
     }
 
-    static func clientAnimateAlong(presentingVC: UIViewController,
-                                   presentedVC: UIViewController,
+    static func clientAnimateAlong(presentingDrawerAnimationActions: DrawerAnimationActions,
+                                   presentedDrawerAnimationActions: DrawerAnimationActions,
                                    _ info: DrawerAnimationInfo) {
-        (presentingVC as? DrawerAnimationParticipant)?.drawerAnimationActions.animateAlong?(info)
-        (presentedVC as? DrawerAnimationParticipant)?.drawerAnimationActions.animateAlong?(info)
+        presentingDrawerAnimationActions.animateAlong?(info)
+        presentedDrawerAnimationActions.animateAlong?(info)
     }
 
-    static func clientCleanupViews(presentingVC: UIViewController,
-                                   presentedVC: UIViewController,
+    static func clientCleanupViews(presentingDrawerAnimationActions: DrawerAnimationActions,
+                                   presentedDrawerAnimationActions: DrawerAnimationActions,
                                    _ endingPosition: UIViewAnimatingPosition,
                                    _ info: DrawerAnimationInfo) {
         var endInfo = info
         endInfo.endPosition = endingPosition
-        (presentingVC as? DrawerAnimationParticipant)?.drawerAnimationActions.cleanup?(info)
-        (presentedVC as? DrawerAnimationParticipant)?.drawerAnimationActions.cleanup?(info)
+        presentingDrawerAnimationActions.cleanup?(info)
+        presentedDrawerAnimationActions.cleanup?(info)
+        NotificationCenter.default.post(notification: DrawerNotification.transitionDidFinish(info: info))
     }
 }

--- a/DrawerKit/DrawerKit/Internal API/DrawerDisplayController+Extensions.swift
+++ b/DrawerKit/DrawerKit/Internal API/DrawerDisplayController+Extensions.swift
@@ -5,7 +5,9 @@ extension DrawerDisplayController: UIViewControllerTransitioningDelegate {
                                        presenting: UIViewController?,
                                        source: UIViewController) -> UIPresentationController? {
         let presentationController = PresentationController(presentingVC: presentingVC,
+                                                            presentingDrawerAnimationActions: presentingDrawerAnimationActions,
                                                             presentedVC: presented,
+                                                            presentedDrawerAnimationActions: presentedDrawerAnimationActions,
                                                             configuration: configuration,
                                                             inDebugMode: inDebugMode)
         presentationController.delegate = self
@@ -15,11 +17,17 @@ extension DrawerDisplayController: UIViewControllerTransitioningDelegate {
     public func animationController(forPresented presented: UIViewController,
                                     presenting: UIViewController,
                                     source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-        return AnimationController(isPresentation: true, configuration: configuration)
+        return AnimationController(isPresentation: true,
+                                   configuration: configuration,
+                                   presentingDrawerAnimationActions: presentingDrawerAnimationActions,
+                                   presentedDrawerAnimationActions: presentedDrawerAnimationActions)
     }
 
     public func animationController(forDismissed dismissed: UIViewController) -> UIViewControllerAnimatedTransitioning? {
-        return AnimationController(isPresentation: false, configuration: configuration)
+        return AnimationController(isPresentation: false,
+                                   configuration: configuration,
+                                   presentingDrawerAnimationActions: presentingDrawerAnimationActions,
+                                   presentedDrawerAnimationActions: presentedDrawerAnimationActions)
     }
 
     public func interactionControllerForPresentation(using animator: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Animation.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Animation.swift
@@ -43,16 +43,19 @@ extension PresentationController {
         let autoAnimatesDimming = configuration.handleViewConfiguration.autoAnimatesDimming
         if autoAnimatesDimming { self.handleView?.alpha = handleViewAlpha(at: startingState) }
 
-        AnimationSupport.clientPrepareViews(presentingVC: presentingVC,
-                                            presentedVC: presentedVC,
+        let presentingAnimationActions = self.presentingDrawerAnimationActions
+        let presentedAnimationActions = self.presentedDrawerAnimationActions
+
+        AnimationSupport.clientPrepareViews(presentingDrawerAnimationActions: presentingAnimationActions,
+                                            presentedDrawerAnimationActions: presentedAnimationActions,
                                             info)
 
         animator.addAnimations {
             self.currentDrawerY = endingPositionY
             if autoAnimatesDimming { self.handleView?.alpha = endingHandleViewAlpha }
             if maxCornerRadius != 0 { self.currentDrawerCornerRadius = endingCornerRadius }
-            AnimationSupport.clientAnimateAlong(presentingVC: presentingVC,
-                                                presentedVC: presentedVC,
+            AnimationSupport.clientAnimateAlong(presentingDrawerAnimationActions: presentingAnimationActions,
+                                                presentedDrawerAnimationActions: presentedAnimationActions,
                                                 info)
         }
 
@@ -84,8 +87,8 @@ extension PresentationController {
                 self.currentDrawerCornerRadius = 0
             }
 
-            AnimationSupport.clientCleanupViews(presentingVC: presentingVC,
-                                                presentedVC: presentedVC,
+            AnimationSupport.clientCleanupViews(presentingDrawerAnimationActions: presentingAnimationActions,
+                                                presentedDrawerAnimationActions: presentedAnimationActions,
                                                 endingPosition,
                                                 info)
         }

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Gestures.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Gestures.swift
@@ -5,6 +5,7 @@ extension PresentationController {
         guard let tapGesture = drawerFullExpansionTapGR else { return }
         let tapY = tapGesture.location(in: presentedView).y
         guard tapY < drawerPartialHeight else { return }
+        NotificationCenter.default.post(notification: DrawerNotification.drawerInteriorTapped)
         animateTransition(to: .fullyExpanded)
     }
 
@@ -12,6 +13,7 @@ extension PresentationController {
         guard let tapGesture = drawerDismissalTapGR else { return }
         let tapY = tapGesture.location(in: containerView).y
         guard tapY < currentDrawerY else { return }
+        NotificationCenter.default.post(notification: DrawerNotification.drawerExteriorTapped)
         tapGesture.isEnabled = false
         presentedViewController.dismiss(animated: true)
     }

--- a/DrawerKit/DrawerKit/Internal API/PresentationController.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController.swift
@@ -5,18 +5,25 @@ final class PresentationController: UIPresentationController {
     let inDebugMode: Bool
     let handleView: UIView?
 
+    let presentingDrawerAnimationActions: DrawerAnimationActions
+    let presentedDrawerAnimationActions: DrawerAnimationActions
+
     var drawerFullExpansionTapGR: UITapGestureRecognizer?
     var drawerDismissalTapGR: UITapGestureRecognizer?
     var drawerDragGR: UIPanGestureRecognizer?
     var lastDrawerState: DrawerState = .collapsed
 
     init(presentingVC: UIViewController?,
+         presentingDrawerAnimationActions: DrawerAnimationActions,
          presentedVC: UIViewController,
+         presentedDrawerAnimationActions: DrawerAnimationActions,
          configuration: DrawerConfiguration,
          inDebugMode: Bool = false) {
         self.configuration = configuration
         self.inDebugMode = inDebugMode
         self.handleView = (configuration.hasHandleView ? UIView() : nil)
+        self.presentingDrawerAnimationActions = presentingDrawerAnimationActions
+        self.presentedDrawerAnimationActions = presentedDrawerAnimationActions
         super.init(presentedViewController: presentedVC, presenting: presentingVC)
     }
 }

--- a/DrawerKit/DrawerKit/Public API/DrawerDisplayController.swift
+++ b/DrawerKit/DrawerKit/Public API/DrawerDisplayController.swift
@@ -15,6 +15,9 @@ public final class DrawerDisplayController: NSObject {
     weak var presentingVC: UIViewController?
     /* strong */ var presentedVC: (UIViewController & DrawerPresentable)
 
+    let presentingDrawerAnimationActions: DrawerAnimationActions
+    let presentedDrawerAnimationActions: DrawerAnimationActions
+
     let inDebugMode: Bool
 
     /// Initialiser for `DrawerDisplayController`.
@@ -38,6 +41,19 @@ public final class DrawerDisplayController: NSObject {
         self.presentedVC = presentedViewController
         self.configuration = configuration
         self.inDebugMode = inDebugMode
+
+        if let presentingAsDrawerParticipant = presentingViewController as? DrawerAnimationParticipant {
+            self.presentingDrawerAnimationActions = presentingAsDrawerParticipant.drawerAnimationActions
+        } else {
+            self.presentingDrawerAnimationActions = DrawerAnimationActions()
+        }
+
+        if let presentedAsDrawerParticipant = presentedViewController as? DrawerAnimationParticipant {
+            self.presentedDrawerAnimationActions = presentedAsDrawerParticipant.drawerAnimationActions
+        } else {
+            self.presentedDrawerAnimationActions = DrawerAnimationActions()
+        }
+
         super.init()
         presentedViewController.transitioningDelegate = self
         presentedViewController.modalPresentationStyle = .custom

--- a/DrawerKit/DrawerKit/Public API/DrawerNotifications.swift
+++ b/DrawerKit/DrawerKit/Public API/DrawerNotifications.swift
@@ -1,0 +1,26 @@
+import UIKit
+
+public enum DrawerNotification: NotificationEnum {
+    case transitionWillStart(info: DrawerAnimationInfo)
+    case transitionDidFinish(info: DrawerAnimationInfo)
+    case drawerInteriorTapped
+    case drawerExteriorTapped
+
+    public var name: Notification.Name {
+        switch self {
+        case .transitionWillStart:
+            return DrawerNotification.transitionWillStartNotification
+        case .transitionDidFinish:
+            return DrawerNotification.transitionDidFinishNotification
+        case .drawerInteriorTapped:
+            return DrawerNotification.drawerInteriorTappedNotification
+        case .drawerExteriorTapped:
+            return DrawerNotification.drawerExteriorTappedNotification
+        }
+    }
+
+    private static let transitionWillStartNotification = Notification.Name(rawValue: "DrawerNotification.transitionWillStart")
+    private static let transitionDidFinishNotification = Notification.Name(rawValue: "DrawerNotification.transitionDidFinish")
+    private static let drawerInteriorTappedNotification = Notification.Name(rawValue: "DrawerNotification.drawerInteriorTapped")
+    private static let drawerExteriorTappedNotification = Notification.Name(rawValue: "DrawerNotification.drawerExteriorTapped")
+}

--- a/DrawerKit/DrawerKit/Public API/Notifications.swift
+++ b/DrawerKit/DrawerKit/Public API/Notifications.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+public class NotificationToken {
+    public let token: NSObjectProtocol
+    public let center: NotificationCenter
+
+    init(token: NSObjectProtocol, center: NotificationCenter) {
+        self.token = token
+        self.center = center
+    }
+    
+    deinit { center.removeObserver(token) }
+}
+
+public protocol NotificationEnum {
+    var name: Notification.Name { get }
+}
+
+extension NotificationCenter {
+    private static let notificationKey = "notificationKey"
+
+    public func addObserver<A: NotificationEnum>(name: Notification.Name,
+                                                 object: Any? = nil, queue: OperationQueue? = nil,
+                                                 using block: @escaping (A, Any?) -> ()) -> NotificationToken {
+        let token = addObserver(forName: name, object: object, queue: queue, using: { note in
+            guard let note = note.userInfo?[NotificationCenter.notificationKey] as? A else { fatalError("incorrect notification key type") }
+            block(note, object)
+        })
+
+        return NotificationToken(token: token, center: self)
+    }
+
+    internal func post(notification: NotificationEnum, object: Any? = nil) {
+        let userInfo = [NotificationCenter.notificationKey: notification]
+        post(name: notification.name, object: object, userInfo: userInfo)
+    }
+}

--- a/DrawerKit/DrawerKit/Public API/Structs/DrawerAnimationActions.swift
+++ b/DrawerKit/DrawerKit/Public API/Structs/DrawerAnimationActions.swift
@@ -23,17 +23,17 @@ public struct DrawerAnimationActions {
     /// the view controllers involved, if they conform to `DrawerAnimationParticipant`,
     /// that they can now prepare their views for the drawer transition animation
     /// about to start.
-    public var prepare: PrepareHandler?
+    let prepare: PrepareHandler?
 
     /// A closure used as a call-back by the drawer transition process to inform
     /// the view controllers involved, if they conform to `DrawerAnimationParticipant`,
     /// that they can now perform animations in their views along with the drawer
     /// transition animation currently in progress.
-    public var animateAlong: AnimateAlongHandler?
+    let animateAlong: AnimateAlongHandler?
 
     /// A closure used as a call-back by the drawer transition process to inform
     /// the view controllers involved, if they conform to `DrawerAnimationParticipant`,
     /// that they can now cleanup their views since the drawer transition animation
     /// has completed.
-    public var cleanup: CleanupHandler?
+    let cleanup: CleanupHandler?
 }

--- a/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
@@ -2,9 +2,24 @@ import UIKit
 import DrawerKit
 
 class PresentedViewController: UIViewController {
+    private var notificationToken: NotificationToken!
+
     @IBOutlet weak var presentedView: PresentedView!
     @IBAction func dismissButtonTapped() {
         dismiss(animated: true)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.notificationToken = NotificationCenter.default.addObserver(name: DrawerNotification.drawerExteriorTapped.name) {
+            (notification: DrawerNotification, object: Any?) in
+            switch notification {
+            case .drawerExteriorTapped:
+                print("drawerExteriorTapped")
+            default:
+                break
+            }
+        }
     }
 }
 
@@ -23,8 +38,8 @@ extension PresentedViewController: DrawerPresentable {
 
 extension PresentedViewController: DrawerAnimationParticipant {
     public var drawerAnimationActions: DrawerAnimationActions {
-        var actions = DrawerAnimationActions()
-        actions.prepare = { [weak self] info in
+        let prepareAction: DrawerAnimationActions.PrepareHandler = {
+            [weak self] info in
             switch (info.startDrawerState, info.endDrawerState) {
             case (.collapsed, .partiallyExpanded):
                 self?.presentedView.prepareCollapsedToPartiallyExpanded()
@@ -42,7 +57,9 @@ extension PresentedViewController: DrawerAnimationParticipant {
                 break
             }
         }
-        actions.animateAlong = { [weak self] info in
+
+        let animateAlongAction: DrawerAnimationActions.AnimateAlongHandler = {
+            [weak self] info in
             switch (info.startDrawerState, info.endDrawerState) {
             case (.collapsed, .partiallyExpanded):
                 self?.presentedView.animateAlongCollapsedToPartiallyExpanded()
@@ -60,7 +77,9 @@ extension PresentedViewController: DrawerAnimationParticipant {
                 break
             }
         }
-        actions.cleanup = { [weak self] info in
+
+        let cleanupAction: DrawerAnimationActions.CleanupHandler = {
+            [weak self] info in
             switch (info.startDrawerState, info.endDrawerState) {
             case (.collapsed, .partiallyExpanded):
                 self?.presentedView.cleanupCollapsedToPartiallyExpanded()
@@ -78,6 +97,9 @@ extension PresentedViewController: DrawerAnimationParticipant {
                 break
             }
         }
-        return actions
+
+        return DrawerAnimationActions(prepare: prepareAction,
+                                      animateAlong: animateAlongAction,
+                                      cleanup: cleanupAction)
     }
 }

--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ Please do play with the demo app and try different configuration options because
 	</table>
 </p>
 
+## What's new in version 0.3.1?
+
+- Better support for concurrent animations: in previous versions, the actual presenting view
+controller wasn't necessarily what you'd think is the presenting view controller, which caused
+problems when trying to animate its view concurrently with the drawer animation. Now, although
+it's still the case that the presenting view controller may not be the view controller you think
+it is, the view controller that you think is the presenting view controller and which you add
+conformance to `DrawerAnimationParticipant` is the view controller whose animation closures get invoked.
+
+- Notifications: it's now possible to subscribe to notifications indicating when the drawer is
+tapped (both in its interior and in its exterior), when drawer transitions are about to start,
+and when they're completed.
+
 ## What's new in version 0.3.0?
 
 Please note that v. `0.3.0` is not backwards-compatible with v. 0.2.

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   xcode:
-    version: "9.0"
+    version: "9.1"
 
 dependencies:
   cache_directories:
@@ -8,14 +8,14 @@ dependencies:
 
 test:
   override:
-    - set -o pipefail && 
-      xcodebuild 
-        CODE_SIGNING_REQUIRED=NO 
+    - set -o pipefail &&
+      xcodebuild
+        CODE_SIGNING_REQUIRED=NO
         CODE_SIGN_IDENTITY=
-        PROVISIONING_PROFILE= 
+        PROVISIONING_PROFILE=
           -sdk iphonesimulator
-          -destination 'platform=iOS Simulator,OS=11.0.1,name=iPhone 7'
-          -workspace DrawerKit.xcworkspace 
+          -destination 'platform=iOS Simulator,OS=11.1,name=iPhone 7'
+          -workspace DrawerKit.xcworkspace
           -scheme "DrawerKitDemo"
       clean build test
     - pod lib lint


### PR DESCRIPTION
No review required.

- Better support for concurrent animations: in previous versions, the actual presenting view controller wasn't necessarily what you'd think is the presenting view controller, which caused problems when trying to animate its view concurrently with the drawer animation. Now, although it's still the case that the presenting view controller may not be the view controller you think it is, the view controller that you think is the presenting view controller and which you add conformance to `DrawerAnimationParticipant` is the view controller whose animation closures get invoked.

- Notifications: it's now possible to subscribe to notifications indicating when the drawer is tapped (both in its interior and in its exterior), when drawer transitions are about to start, and when they're completed.
