### PR TITLE
DrawerKit 0.3.2: Fixes an issue with typed notifications in DrawerKit 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # DrawerKit
 
+## v. 0.3.2
+
+- Fixes an issue with typed notifications.
+
 ## v. 0.3.1
 
 - Better support for concurrent animations: in previous versions, the actual presenting view controller wasn't necessarily what you'd think is the presenting view controller, which caused problems when trying to animate its view concurrently with the drawer animation. Now, although it's still the case that the presenting view controller may not be the view controller you think it is, the view controller that you think is the presenting view controller and which you add conformance to `DrawerAnimationParticipant` is the view controller whose animation closures get invoked.

--- a/DrawerKit.podspec
+++ b/DrawerKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name          = "DrawerKit"
-  s.version       = "0.3.1"
+  s.version       = "0.3.2"
   s.summary       = "An implementation of an interactive and animated view, similar to what you see in Apple Maps"
 
   s.description   = <<-DESC

--- a/DrawerKit/DrawerKit/Public API/DrawerNotifications.swift
+++ b/DrawerKit/DrawerKit/Public API/DrawerNotifications.swift
@@ -19,8 +19,8 @@ public enum DrawerNotification: NotificationEnum {
         }
     }
 
-    private static let transitionWillStartNotification = Notification.Name(rawValue: "DrawerNotification.transitionWillStart")
-    private static let transitionDidFinishNotification = Notification.Name(rawValue: "DrawerNotification.transitionDidFinish")
-    private static let drawerInteriorTappedNotification = Notification.Name(rawValue: "DrawerNotification.drawerInteriorTapped")
-    private static let drawerExteriorTappedNotification = Notification.Name(rawValue: "DrawerNotification.drawerExteriorTapped")
+    public static let transitionWillStartNotification = Notification.Name(rawValue: "DrawerNotification.transitionWillStart")
+    public static let transitionDidFinishNotification = Notification.Name(rawValue: "DrawerNotification.transitionDidFinish")
+    public static let drawerInteriorTappedNotification = Notification.Name(rawValue: "DrawerNotification.drawerInteriorTapped")
+    public static let drawerExteriorTappedNotification = Notification.Name(rawValue: "DrawerNotification.drawerExteriorTapped")
 }

--- a/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
@@ -11,7 +11,8 @@ class PresentedViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.notificationToken = NotificationCenter.default.addObserver(name: DrawerNotification.drawerExteriorTapped.name) {
+        self.notificationToken = NotificationCenter.default
+            .addObserver(name: DrawerNotification.drawerExteriorTappedNotification) {
             (notification: DrawerNotification, object: Any?) in
             switch notification {
             case .drawerExteriorTapped:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Please do play with the demo app and try different configuration options because
 	</table>
 </p>
 
-## What's new in version 0.3.1?
+## What's new in version 0.3.2?
 
 - Better support for concurrent animations: in previous versions, the actual presenting view
 controller wasn't necessarily what you'd think is the presenting view controller, which caused


### PR DESCRIPTION
The static properties in `DrawerNotifications.swift` need to be public. Also changed the example app to illustrate where and how they're used.