### PR TITLE
DrawerKit 0.3.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # DrawerKit
 
+## v. 0.3.4
+
+- Adds a new configuration parameter for the handle view, namely, its vertical position with respect to the presented view's frame.
+
 ## v. 0.3.3
 
 - Fixes an issue where the presented view controller's view might not be laid out properly by the time the drawer's height is requested from it.

--- a/DrawerKit.podspec
+++ b/DrawerKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name          = "DrawerKit"
-  s.version       = "0.3.3"
+  s.version       = "0.3.4"
   s.summary       = "An implementation of an interactive and animated view, similar to what you see in Apple Maps"
 
   s.description   = <<-DESC

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Setup.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Setup.swift
@@ -91,7 +91,7 @@ extension PresentationController {
             handleView.widthAnchor.constraint(equalToConstant: handleConfig.size.width),
             handleView.heightAnchor.constraint(equalToConstant: handleConfig.size.height),
             handleView.centerXAnchor.constraint(equalTo: presentedView.centerXAnchor),
-            handleView.topAnchor.constraint(equalTo: presentedView.topAnchor, constant: 8)
+            handleView.topAnchor.constraint(equalTo: presentedView.topAnchor, constant: handleConfig.top)
             ])
     }
 

--- a/DrawerKit/DrawerKit/Public API/Structs/HandleViewConfiguration.swift
+++ b/DrawerKit/DrawerKit/Public API/Structs/HandleViewConfiguration.swift
@@ -34,6 +34,12 @@ public struct HandleViewConfiguration {
     /// `CGSize(width: 40, height: 6)`.
     public var size: CGSize
 
+    /// The handle view's vertical distance from the top of the drawer. In other words,
+    /// the constant to be used when setting up the layout constraint
+    /// `handleView.topAnchor.constraint(equalTo: presentedView.topAnchor, constant: top)`
+    /// The default value is 8 points.
+    public var top: CGFloat
+
     /// The handle view's corner radius. The default is `CornerRadius.automatic`, which
     /// results in a corner radius equal to half the handle view's height.
     public var cornerRadius: CornerRadius
@@ -41,6 +47,7 @@ public struct HandleViewConfiguration {
     public init(autoAnimatesDimming: Bool = true,
                 backgroundColor: UIColor = .gray,
                 size: CGSize = CGSize(width: 40, height: 6),
+                top: CGFloat = 8,
                 cornerRadius: CornerRadius = .automatic) {
         self.autoAnimatesDimming = autoAnimatesDimming
 
@@ -57,6 +64,8 @@ public struct HandleViewConfiguration {
             self.size = validatedSize
         }
 
+        self.top = max(0, top)
+
         switch cornerRadius {
         case .automatic:
             self.cornerRadius = .automatic
@@ -70,6 +79,7 @@ extension HandleViewConfiguration: Equatable {
     public static func ==(lhs: HandleViewConfiguration, rhs: HandleViewConfiguration) -> Bool {
         return lhs.autoAnimatesDimming == rhs.autoAnimatesDimming
             && lhs.backgroundColor == rhs.backgroundColor
+            && lhs.top == rhs.top
             && lhs.size == rhs.size
             && lhs.cornerRadius == rhs.cornerRadius
     }

--- a/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
@@ -42,6 +42,7 @@ private extension PresenterViewController {
         handleViewConfiguration.autoAnimatesDimming = true
         handleViewConfiguration.backgroundColor = .gray
         handleViewConfiguration.size = CGSize(width: 40, height: 6)
+        handleViewConfiguration.top = 8
         handleViewConfiguration.cornerRadius = .automatic
         configuration.handleViewConfiguration = handleViewConfiguration
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ Please do play with the demo app and try different configuration options because
 	</table>
 </p>
 
+## What's new in version 0.3.4?
+
+- Adds a new configuration parameter for the handle view, namely, its vertical position with
+respect to the presented view's frame.
+
 ## What's new in version 0.3.3?
 
 - Better support for concurrent animations: in previous versions, the actual presenting view


### PR DESCRIPTION
This PR merges `develop` into `master`, bringing it up to version 0.3.4.
No review required.