### PR TITLE
Run transition logic regardless of whether the state matches.

### DIFF
--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Animation.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Animation.swift
@@ -2,8 +2,6 @@ import UIKit
 
 extension PresentationController {
     func animateTransition(to endingState: DrawerState) {
-        guard endingState != currentDrawerState else { return }
-
         let startingState = currentDrawerState
 
         let maxCornerRadius = maximumCornerRadius


### PR DESCRIPTION
When the drawer view is _interactively_ positioned as the same as a fully expanded view, `currentDrawerState` is computed as `fullyExpanded`.

So when the interactive gesture completes, `PresentationController.animateTransition` currently does nothing, since it considered the transition has completed based on `currentDrawerState`. In the end, this causes the completion block not being executed, and the most prominent effect is that the handle is not disappearing in this boundary case.

| Before | After |
| --- | --- |
| ![drawer_kit_fix_before](https://user-images.githubusercontent.com/11806295/33212379-c2ae2222-d15d-11e7-9dc7-fe7a63328819.gif) | <img src="https://user-images.githubusercontent.com/11806295/33212304-63b2200c-d15d-11e7-99d2-ce439877b055.gif" width="300" /> |
