### PR TITLE
Use a container VC to make sure UIKit owned insets do not go wild.

### DIFF
--- a/DrawerKit/DrawerKit/Internal API/AnimationController.swift
+++ b/DrawerKit/DrawerKit/Internal API/AnimationController.swift
@@ -28,7 +28,10 @@ extension AnimationController: UIViewControllerAnimatedTransitioning {
 
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
         let (presentingVC, presentedVC) = viewControllers(transitionContext, isPresentation)
-        if isPresentation { transitionContext.containerView.addSubview(presentedVC.view) }
+        if isPresentation {
+            let controller = presentedVC.presentationController as! PresentationController
+            controller.intermediate.view.addSubview(presentedVC.view)
+        }
 
         let duration = transitionDuration(using: transitionContext)
         let timingCurveProvider = configuration.timingCurveProvider

--- a/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
@@ -21,11 +21,11 @@ private extension PresenterViewController {
         // what you need to configure differently. They're all listed here just so you
         // can see what can be configured. The values listed are the default ones,
         // except where indicated otherwise.
-        configuration.totalDurationInSeconds = 3 // default is 0.4
+        configuration.totalDurationInSeconds = 0.4
         configuration.durationIsProportionalToDistanceTraveled = false
         // default is UISpringTimingParameters()
         configuration.timingCurveProvider = UISpringTimingParameters(dampingRatio: 0.8)
-        configuration.fullExpansionBehaviour = .leavesCustomGap(gap: 100) // default is .coversFullScreen
+        configuration.fullExpansionBehaviour = .coversFullScreen
         configuration.supportsPartialExpansion = true
         configuration.dismissesInStages = true
         configuration.isDrawerDraggable = true

--- a/DrawerKitDemo/DrawerKitDemo/Storyboards/Base.lproj/Main.storyboard
+++ b/DrawerKitDemo/DrawerKitDemo/Storyboards/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="uBw-Sr-LpF">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="uBw-Sr-LpF">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -138,7 +138,7 @@
                             <constraint firstItem="Ojr-aM-v38" firstAttribute="top" secondItem="dEa-Pl-yQz" secondAttribute="bottom" constant="20" id="Dgd-aQ-agb"/>
                             <constraint firstItem="dEa-Pl-yQz" firstAttribute="top" secondItem="69I-et-UOX" secondAttribute="bottom" constant="100" id="Eai-cn-LDj"/>
                             <constraint firstItem="dEa-Pl-yQz" firstAttribute="leading" secondItem="tAJ-xI-Qxr" secondAttribute="leading" id="Vcw-46-NLg"/>
-                            <constraint firstItem="Jth-UI-73K" firstAttribute="top" secondItem="tAJ-xI-Qxr" secondAttribute="top" constant="28" id="aH2-1L-AcL"/>
+                            <constraint firstItem="Jth-UI-73K" firstAttribute="top" secondItem="bMW-fV-gMF" secondAttribute="bottom" constant="8" id="aH2-1L-AcL"/>
                             <constraint firstItem="Ojr-aM-v38" firstAttribute="leading" secondItem="tAJ-xI-Qxr" secondAttribute="leadingMargin" constant="10" id="cWU-AN-kgF"/>
                             <constraint firstItem="qPD-ym-Fa5" firstAttribute="top" secondItem="69I-et-UOX" secondAttribute="bottom" constant="25" id="cpO-2w-akW"/>
                             <constraint firstAttribute="trailing" secondItem="dEa-Pl-yQz" secondAttribute="trailing" id="gI5-Vo-Tk3"/>


### PR DESCRIPTION
Fixes #31.

### TL;DR
If the drawer content is laid out against (1) safe area top or (2) top layout guide, these are now in effect throughout the entire presentation time, **regardless of the drawer being fully expanded or not**.

### Details
The safe area mechanism (and its earlier variant `(top|bottom)LayoutGuide`) appears to be dependent on the view origin. If the view does not lie at (0, 0) of the screen, UIKit would not consider the view overlapping with top system bars, thus having a safe area top inset of **zero** (or top layout guide length).

Jeez. ZERO.

Fortunately, child VCs inherit safe area insets (and layout guides) from their parent VCs. So a full-screen transparent container VC is added. This container VC manages the presented drawer, so that the drawer now gets system layout insets at all phases of presentation. 💁‍♂️ 

### Note
This PR makes the drawer content in the Demo app layouts against the top layout guide.


### GIF
| Before | After (Reversed) |
| --- | --- |
| ![drawer_kit_top_inset_before](https://user-images.githubusercontent.com/11806295/33217446-f44e1390-d172-11e7-8325-794ca889947d.gif) | ![drawer_kit_top_inset](https://user-images.githubusercontent.com/11806295/33217228-f70decfa-d171-11e7-90ee-a925fc0efc61.gif) |
