### PR TITLE
Support modal presentation on top of the drawer.

### DIFF
--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Animation.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Animation.swift
@@ -85,6 +85,8 @@ extension PresentationController {
                 self.currentDrawerCornerRadius = 0
             }
 
+            self.targetDrawerState = endingState
+
             AnimationSupport.clientCleanupViews(presentingDrawerAnimationActions: presentingAnimationActions,
                                                 presentedDrawerAnimationActions: presentedAnimationActions,
                                                 endingPosition,

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Gestures.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Gestures.swift
@@ -23,7 +23,8 @@ extension PresentationController {
 
         switch panGesture.state {
         case .began:
-            break
+            startingDrawerStateForDrag = targetDrawerState
+            fallthrough
 
         case .changed:
             currentDrawerY += panGesture.translation(in: view).y
@@ -31,7 +32,7 @@ extension PresentationController {
             currentDrawerCornerRadius = cornerRadius(at: currentDrawerState)
             panGesture.setTranslation(.zero, in: view)
 
-        case .ended, .cancelled:
+        case .ended:
             let drawerSpeedY = panGesture.velocity(in: view).y / containerViewHeight
             let endingState = GeometryEvaluator.nextStateFrom(currentState: currentDrawerState,
                                                               speedY: drawerSpeedY,
@@ -39,6 +40,12 @@ extension PresentationController {
                                                               containerViewHeight: containerViewHeight,
                                                               configuration: configuration)
             animateTransition(to: endingState)
+
+        case .cancelled:
+            if let startingState = startingDrawerStateForDrag {
+                startingDrawerStateForDrag = nil
+                animateTransition(to: startingState)
+            }
 
         default:
             break

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Gestures.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Gestures.swift
@@ -23,23 +23,15 @@ extension PresentationController {
 
         switch panGesture.state {
         case .began:
-            lastDrawerState = GeometryEvaluator.drawerState(for: currentDrawerY,
-                                                            drawerPartialHeight: drawerPartialHeight,
-                                                            containerViewHeight: containerViewHeight,
-                                                            configuration: configuration,
-                                                            clampToNearest: true)
+            break
 
         case .changed:
-            lastDrawerState = GeometryEvaluator.drawerState(for: currentDrawerY,
-                                                            drawerPartialHeight: drawerPartialHeight,
-                                                            containerViewHeight: containerViewHeight,
-                                                            configuration: configuration,
-                                                            clampToNearest: true)
             currentDrawerY += panGesture.translation(in: view).y
+            targetDrawerState = currentDrawerState
             currentDrawerCornerRadius = cornerRadius(at: currentDrawerState)
             panGesture.setTranslation(.zero, in: view)
 
-        case .ended:
+        case .ended, .cancelled:
             let drawerSpeedY = panGesture.velocity(in: view).y / containerViewHeight
             let endingState = GeometryEvaluator.nextStateFrom(currentState: currentDrawerState,
                                                               speedY: drawerSpeedY,
@@ -47,9 +39,6 @@ extension PresentationController {
                                                               containerViewHeight: containerViewHeight,
                                                               configuration: configuration)
             animateTransition(to: endingState)
-
-        case .cancelled:
-            animateTransition(to: lastDrawerState)
 
         default:
             break

--- a/DrawerKit/DrawerKit/Internal API/PresentationController.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController.swift
@@ -16,6 +16,8 @@ final class PresentationController: UIPresentationController {
     /// progress, the value should be equivalent to `currentDrawerState`.
     var targetDrawerState: DrawerState
 
+    var startingDrawerStateForDrag: DrawerState?
+
     init(presentingVC: UIViewController?,
          presentingDrawerAnimationActions: DrawerAnimationActions,
          presentedVC: UIViewController,

--- a/DrawerKit/DrawerKit/Internal API/PresentationController.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController.swift
@@ -11,7 +11,10 @@ final class PresentationController: UIPresentationController {
     var drawerFullExpansionTapGR: UITapGestureRecognizer?
     var drawerDismissalTapGR: UITapGestureRecognizer?
     var drawerDragGR: UIPanGestureRecognizer?
-    var lastDrawerState: DrawerState = .collapsed
+
+    /// The target state of the drawer. If no presentation animation is in
+    /// progress, the value should be equivalent to `currentDrawerState`.
+    var targetDrawerState: DrawerState
 
     init(presentingVC: UIViewController?,
          presentingDrawerAnimationActions: DrawerAnimationActions,
@@ -24,6 +27,11 @@ final class PresentationController: UIPresentationController {
         self.handleView = (configuration.handleViewConfiguration != nil ? UIView() : nil)
         self.presentingDrawerAnimationActions = presentingDrawerAnimationActions
         self.presentedDrawerAnimationActions = presentedDrawerAnimationActions
+
+        // NOTE: Set the current drawer state to the target state of the initial
+        //       presentation animation.
+        self.targetDrawerState = configuration.supportsPartialExpansion ? .partiallyExpanded : .fullyExpanded
+
         super.init(presentedViewController: presentedVC, presenting: presentingVC)
     }
 }
@@ -33,9 +41,8 @@ extension PresentationController {
         var frame: CGRect = .zero
         frame.size = size(forChildContentContainer: presentedViewController,
                           withParentContainerSize: containerViewSize)
-        let state: DrawerState = (supportsPartialExpansion ? .partiallyExpanded : .fullyExpanded)
         let drawerFullY = configuration.fullExpansionBehaviour.drawerFullY
-        frame.origin.y = GeometryEvaluator.drawerPositionY(for: state,
+        frame.origin.y = GeometryEvaluator.drawerPositionY(for: targetDrawerState,
                                                            drawerPartialHeight: drawerPartialHeight,
                                                            containerViewHeight: containerViewHeight,
                                                            drawerFullY: drawerFullY)

--- a/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
@@ -23,9 +23,7 @@ class PresentedViewController: UIViewController {
         }
     }
 
-    @IBAction func unwindFromModal(with segue: UIStoryboardSegue) {
-        print("Unwound from the modal.")
-    }
+    @IBAction func unwindFromModal(with segue: UIStoryboardSegue) {}
 }
 
 extension PresentedViewController: UIScrollViewDelegate {

--- a/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
@@ -22,6 +22,10 @@ class PresentedViewController: UIViewController {
             }
         }
     }
+
+    @IBAction func unwindFromModal(with segue: UIStoryboardSegue) {
+        print("Unwound from the modal.")
+    }
 }
 
 extension PresentedViewController: UIScrollViewDelegate {

--- a/DrawerKitDemo/DrawerKitDemo/Storyboards/Base.lproj/Main.storyboard
+++ b/DrawerKitDemo/DrawerKitDemo/Storyboards/Base.lproj/Main.storyboard
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="uBw-Sr-LpF">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="uBw-Sr-LpF">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -130,6 +131,12 @@
                                     <outlet property="delegate" destination="9a9-ft-1GT" id="Ta0-1G-Esp"/>
                                 </connections>
                             </scrollView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="detailDisclosure" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ztp-Cf-a4s">
+                                <rect key="frame" x="235" y="32" width="22" height="22"/>
+                                <connections>
+                                    <segue destination="ILn-GS-avA" kind="presentation" id="Dds-Br-1fx"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="0.98065741760000003" green="1" blue="0.90980392160000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                         <constraints>
@@ -137,12 +144,14 @@
                             <constraint firstItem="69I-et-UOX" firstAttribute="centerX" secondItem="tAJ-xI-Qxr" secondAttribute="centerX" id="95D-ht-lrm"/>
                             <constraint firstItem="Ojr-aM-v38" firstAttribute="top" secondItem="dEa-Pl-yQz" secondAttribute="bottom" constant="20" id="Dgd-aQ-agb"/>
                             <constraint firstItem="dEa-Pl-yQz" firstAttribute="top" secondItem="69I-et-UOX" secondAttribute="bottom" constant="100" id="Eai-cn-LDj"/>
+                            <constraint firstItem="Ztp-Cf-a4s" firstAttribute="leading" secondItem="Jth-UI-73K" secondAttribute="trailing" constant="8" id="Pr8-hl-LaR"/>
                             <constraint firstItem="dEa-Pl-yQz" firstAttribute="leading" secondItem="tAJ-xI-Qxr" secondAttribute="leading" id="Vcw-46-NLg"/>
                             <constraint firstItem="Jth-UI-73K" firstAttribute="top" secondItem="tAJ-xI-Qxr" secondAttribute="top" constant="28" id="aH2-1L-AcL"/>
                             <constraint firstItem="Ojr-aM-v38" firstAttribute="leading" secondItem="tAJ-xI-Qxr" secondAttribute="leadingMargin" constant="10" id="cWU-AN-kgF"/>
                             <constraint firstItem="qPD-ym-Fa5" firstAttribute="top" secondItem="69I-et-UOX" secondAttribute="bottom" constant="25" id="cpO-2w-akW"/>
                             <constraint firstAttribute="trailing" secondItem="dEa-Pl-yQz" secondAttribute="trailing" id="gI5-Vo-Tk3"/>
                             <constraint firstItem="Jth-UI-73K" firstAttribute="centerX" secondItem="tAJ-xI-Qxr" secondAttribute="centerX" id="hN7-u7-BLQ"/>
+                            <constraint firstItem="Ztp-Cf-a4s" firstAttribute="centerY" secondItem="Jth-UI-73K" secondAttribute="centerY" id="m1M-EE-Co9"/>
                             <constraint firstAttribute="bottomMargin" secondItem="Ojr-aM-v38" secondAttribute="bottom" constant="20" id="r5Q-A1-OUj"/>
                             <constraint firstItem="qPD-ym-Fa5" firstAttribute="centerX" secondItem="tAJ-xI-Qxr" secondAttribute="centerX" id="sgV-nk-lFF"/>
                             <constraint firstAttribute="trailingMargin" secondItem="Ojr-aM-v38" secondAttribute="trailing" constant="10" id="tkz-7e-SmV"/>
@@ -162,6 +171,42 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="mjN-SN-YOS" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-4889" y="-3600"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="hN9-WT-acc">
+            <objects>
+                <viewController modalPresentationStyle="overFullScreen" id="ILn-GS-avA" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="tW2-fX-OIl"/>
+                        <viewControllerLayoutGuide type="bottom" id="R2W-iO-cgi"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="M1z-fN-qgZ">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kp1-y6-ing">
+                                <rect key="frame" x="165.5" y="311.5" width="44" height="44"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="kp1-y6-ing" secondAttribute="height" multiplier="1:1" id="ThG-Ko-duV"/>
+                                    <constraint firstAttribute="width" constant="44" id="nPw-ft-jKu"/>
+                                </constraints>
+                                <state key="normal" title="Button" image="close"/>
+                                <connections>
+                                    <segue destination="qRR-E6-YWn" kind="unwind" unwindAction="unwindFromModalWith:" id="WaZ-5b-Pw8"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="kp1-y6-ing" firstAttribute="centerX" secondItem="M1z-fN-qgZ" secondAttribute="centerX" id="0cZ-EC-Emq"/>
+                            <constraint firstItem="kp1-y6-ing" firstAttribute="centerY" secondItem="M1z-fN-qgZ" secondAttribute="centerY" id="etG-er-ypt"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="pVR-K0-1GK" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <exit id="qRR-E6-YWn" userLabel="Exit" sceneMemberID="exit"/>
+            </objects>
+            <point key="canvasLocation" x="-4071.1999999999998" y="-3600.4497751124441"/>
         </scene>
     </scenes>
     <resources>


### PR DESCRIPTION
1. Support modal presentation over the drawer.

    The presented view controller must however use `overFullscreen` for the drawer content to be placed correctly. This is due to the default `fullScreen` presentation style _not_ asking DrawerKit for the correct frame before the dismissal animation begins. This causes the drawer being visible in the incorrect position until the dismissal animation completes.

2. Update the demo app to showcase the support.

| Modal over Partially Expanded Drawer | Modal over Fully Expanded Drawer |
| --- | --- |
| ![partially_expanded](https://user-images.githubusercontent.com/11806295/38376762-433c4ebe-38f1-11e8-898f-b870a62c4143.gif) | ![fully-expanded](https://user-images.githubusercontent.com/11806295/38376768-45d1b132-38f1-11e8-8f4e-3273efa916a6.gif) |