### PR TITLE
Fixed an issue of content taps being cancelled by the drawer tap recognisers.

### DIFF
--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Animation.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Animation.swift
@@ -85,6 +85,8 @@ extension PresentationController {
                 self.currentDrawerCornerRadius = 0
             }
 
+            self.lastDrawerState = endingState
+
             AnimationSupport.clientCleanupViews(presentingDrawerAnimationActions: presentingAnimationActions,
                                                 presentedDrawerAnimationActions: presentedAnimationActions,
                                                 endingPosition,

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Gestures.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Gestures.swift
@@ -56,3 +56,16 @@ extension PresentationController {
         }
     }
 }
+
+extension PresentationController: UIGestureRecognizerDelegate {
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+        if let view = gestureRecognizer.view,
+           view.isDescendant(of: presentedViewController.view),
+           let subview = view.hitTest(touch.location(in: view), with: nil),
+           subview is UIControl {
+            return false
+        } else {
+            return true
+        }
+    }
+}

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Gestures.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Gestures.swift
@@ -57,9 +57,8 @@ extension PresentationController: UIGestureRecognizerDelegate {
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
         if let view = gestureRecognizer.view,
            view.isDescendant(of: presentedViewController.view),
-           let subview = view.hitTest(touch.location(in: view), with: nil),
-           subview is UIControl {
-            return false
+           let subview = view.hitTest(touch.location(in: view), with: nil) {
+            return !(subview is UIControl)
         } else {
             return true
         }

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Setup.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Setup.swift
@@ -10,6 +10,10 @@ extension PresentationController {
                                                 action: #selector(handleDrawerFullExpansionTap))
         tapGesture.numberOfTouchesRequired = 1
         tapGesture.numberOfTapsRequired = numTapsRequired
+        tapGesture.cancelsTouchesInView = false
+        tapGesture.delaysTouchesBegan = false
+        tapGesture.delaysTouchesEnded = false
+        tapGesture.delegate = self
         presentedView?.addGestureRecognizer(tapGesture)
         drawerFullExpansionTapGR = tapGesture
     }
@@ -35,6 +39,10 @@ extension PresentationController {
                                                 action: #selector(handleDrawerDismissalTap))
         tapGesture.numberOfTouchesRequired = 1
         tapGesture.numberOfTapsRequired = numTapsRequired
+        tapGesture.cancelsTouchesInView = false
+        tapGesture.delaysTouchesBegan = false
+        tapGesture.delaysTouchesEnded = false
+        tapGesture.delegate = self
         containerView?.addGestureRecognizer(tapGesture)
         drawerDismissalTapGR = tapGesture
     }

--- a/DrawerKit/DrawerKit/Internal API/PresentationController.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController.swift
@@ -11,7 +11,12 @@ final class PresentationController: UIPresentationController {
     var drawerFullExpansionTapGR: UITapGestureRecognizer?
     var drawerDismissalTapGR: UITapGestureRecognizer?
     var drawerDragGR: UIPanGestureRecognizer?
-    var lastDrawerState: DrawerState = .collapsed
+    var lastDrawerState: DrawerState {
+        didSet {
+            drawerDismissalTapGR?.isEnabled = lastDrawerState == .partiallyExpanded
+            drawerFullExpansionTapGR?.isEnabled = lastDrawerState == .partiallyExpanded
+        }
+    }
 
     init(presentingVC: UIViewController?,
          presentingDrawerAnimationActions: DrawerAnimationActions,
@@ -24,6 +29,7 @@ final class PresentationController: UIPresentationController {
         self.handleView = (configuration.handleViewConfiguration != nil ? UIView() : nil)
         self.presentingDrawerAnimationActions = presentingDrawerAnimationActions
         self.presentedDrawerAnimationActions = presentedDrawerAnimationActions
+        self.lastDrawerState = configuration.supportsPartialExpansion ? .partiallyExpanded : .fullyExpanded
         super.init(presentedViewController: presentedVC, presenting: presentingVC)
     }
 }
@@ -33,9 +39,8 @@ extension PresentationController {
         var frame: CGRect = .zero
         frame.size = size(forChildContentContainer: presentedViewController,
                           withParentContainerSize: containerViewSize)
-        let state: DrawerState = (supportsPartialExpansion ? .partiallyExpanded : .fullyExpanded)
         let drawerFullY = configuration.fullExpansionBehaviour.drawerFullY
-        frame.origin.y = GeometryEvaluator.drawerPositionY(for: state,
+        frame.origin.y = GeometryEvaluator.drawerPositionY(for: lastDrawerState,
                                                            drawerPartialHeight: drawerPartialHeight,
                                                            containerViewHeight: containerViewHeight,
                                                            drawerFullY: drawerFullY)


### PR DESCRIPTION
The two tap recognisers installed by DrawerKit, if enabled, would cancel the delivery of touch events to the content view by default. This causes problems with at least `UITableView`, whose selection mechanism relies on these events.

This branch also enables controls within the drawer content to be interactive, even if the drawer is not fully expanded.