### PR TITLE
Pull to Dismiss UIScrollView drawers.

### DIFF
--- a/DrawerKit/DrawerKit.xcodeproj/project.pbxproj
+++ b/DrawerKit/DrawerKit.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		654604CE207BD4BC00B72395 /* DrawerPresentationControlling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654604CD207BD4BC00B72395 /* DrawerPresentationControlling.swift */; };
+		9A158BC22076C92200FD4113 /* PresentationController+PullToDismiss.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A158BC12076C92200FD4113 /* PresentationController+PullToDismiss.swift */; };
 		CB1B6DF31FC346CC006C1F89 /* DrawerShadowConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB1B6DF21FC346CC006C1F89 /* DrawerShadowConfiguration.swift */; };
 		CB1B6E011FC8629B006C1F89 /* DrawerBorderConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB1B6E001FC8629B006C1F89 /* DrawerBorderConfiguration.swift */; };
 		CB2CB7941F8E934500AA152D /* DrawerPresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2CB78D1F8E934500AA152D /* DrawerPresentable.swift */; };
@@ -40,6 +42,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		654604CD207BD4BC00B72395 /* DrawerPresentationControlling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerPresentationControlling.swift; sourceTree = "<group>"; };
+		9A158BC12076C92200FD4113 /* PresentationController+PullToDismiss.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PresentationController+PullToDismiss.swift"; sourceTree = "<group>"; };
 		CB1B6DF21FC346CC006C1F89 /* DrawerShadowConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DrawerShadowConfiguration.swift; sourceTree = "<group>"; };
 		CB1B6E001FC8629B006C1F89 /* DrawerBorderConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DrawerBorderConfiguration.swift; sourceTree = "<group>"; };
 		CB2CB78D1F8E934500AA152D /* DrawerPresentable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DrawerPresentable.swift; sourceTree = "<group>"; };
@@ -107,6 +111,7 @@
 				CB6F86B51F9C03F8000FA37A /* PresentationController+Setup.swift */,
 				CB6F86B91F9C05E6000FA37A /* PresentationController+Gestures.swift */,
 				CB6F86B71F9C0539000FA37A /* PresentationController+Properties.swift */,
+				9A158BC12076C92200FD4113 /* PresentationController+PullToDismiss.swift */,
 				CB6F86BB1F9C06D6000FA37A /* PresentationController+Animation.swift */,
 				CB6F86B31F9C036D000FA37A /* PresentationController+Utilities.swift */,
 				CB619CEB1F8FFBAD0076E1DE /* InteractionController.swift */,
@@ -123,6 +128,7 @@
 				CB2CB78E1F8E934500AA152D /* DrawerCoordinating.swift */,
 				CB2CB78D1F8E934500AA152D /* DrawerPresentable.swift */,
 				CB5AF7FF1F9BDAC5000B2DC9 /* DrawerAnimationParticipant.swift */,
+				654604CD207BD4BC00B72395 /* DrawerPresentationControlling.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -267,6 +273,7 @@
 				CB619CEC1F8FFBAD0076E1DE /* InteractionController.swift in Sources */,
 				CB6F86B81F9C0539000FA37A /* PresentationController+Properties.swift in Sources */,
 				CB2CB7AD1F8E9D9900AA152D /* DrawerDisplayController+Extensions.swift in Sources */,
+				9A158BC22076C92200FD4113 /* PresentationController+PullToDismiss.swift in Sources */,
 				CB5AF8111F9BE95C000B2DC9 /* DrawerAnimationInfo+Configuration.swift in Sources */,
 				CB2CB79F1F8E951900AA152D /* AnimationController.swift in Sources */,
 				CBACF6B31F9C622300C15CA3 /* AnimationSupport.swift in Sources */,
@@ -288,6 +295,7 @@
 				CB6F86BC1F9C06D6000FA37A /* PresentationController+Animation.swift in Sources */,
 				CB9101C61F8F791A000EAC41 /* PresentationController+Configuration.swift in Sources */,
 				CB2CB79E1F8E951900AA152D /* PresentationController.swift in Sources */,
+				654604CE207BD4BC00B72395 /* DrawerPresentationControlling.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Animation.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Animation.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 extension PresentationController {
-    func animateTransition(to endingState: DrawerState) {
+    func animateTransition(to endingState: DrawerState, animateAlongside: (() -> Void)? = nil, completion: (() -> Void)? = nil) {
         let startingState = currentDrawerState
 
         let maxCornerRadius = maximumCornerRadius
@@ -48,6 +48,8 @@ extension PresentationController {
                                             presentedDrawerAnimationActions: presentedAnimationActions,
                                             info)
 
+        targetDrawerState = endingState
+
         animator.addAnimations {
             self.currentDrawerY = endingPositionY
             if autoAnimatesDimming { self.handleView?.alpha = endingHandleViewAlpha }
@@ -55,6 +57,7 @@ extension PresentationController {
             AnimationSupport.clientAnimateAlong(presentingDrawerAnimationActions: presentingAnimationActions,
                                                 presentedDrawerAnimationActions: presentedAnimationActions,
                                                 info)
+            animateAlongside?()
         }
 
         animator.addCompletion { endingPosition in
@@ -85,12 +88,19 @@ extension PresentationController {
                 self.currentDrawerCornerRadius = 0
             }
 
-            self.targetDrawerState = endingState
+            if endingPosition != .end {
+                self.targetDrawerState = GeometryEvaluator.drawerState(for: self.currentDrawerY,
+                                                                       drawerPartialHeight: self.drawerPartialY,
+                                                                       containerViewHeight: self.containerViewHeight,
+                                                                       configuration: self.configuration)
+            }
 
             AnimationSupport.clientCleanupViews(presentingDrawerAnimationActions: presentingAnimationActions,
                                                 presentedDrawerAnimationActions: presentedAnimationActions,
                                                 endingPosition,
                                                 info)
+
+            completion?()
         }
 
         animator.startAnimation()

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Gestures.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Gestures.swift
@@ -27,9 +27,7 @@ extension PresentationController {
             fallthrough
 
         case .changed:
-            currentDrawerY += panGesture.translation(in: view).y
-            targetDrawerState = currentDrawerState
-            currentDrawerCornerRadius = cornerRadius(at: currentDrawerState)
+            applyTranslationY(panGesture.translation(in: view).y)
             panGesture.setTranslation(.zero, in: view)
 
         case .ended:
@@ -51,11 +49,18 @@ extension PresentationController {
             break
         }
     }
+
+    func applyTranslationY(_ translationY: CGFloat) {
+        currentDrawerY += translationY
+        targetDrawerState = currentDrawerState
+        currentDrawerCornerRadius = cornerRadius(at: currentDrawerState)
+    }
 }
 
 extension PresentationController: UIGestureRecognizerDelegate {
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
-        if let view = gestureRecognizer.view,
+        if gestureRecognizer is UITapGestureRecognizer,
+           let view = gestureRecognizer.view,
            view.isDescendant(of: presentedViewController.view),
            let subview = view.hitTest(touch.location(in: view), with: nil) {
             return !(subview is UIControl)

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+PullToDismiss.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+PullToDismiss.swift
@@ -1,0 +1,111 @@
+extension PresentationController: UIScrollViewDelegate {
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        guard !scrollViewNeedsTransitionAsDragEnds else { return }
+
+        scrollStartDrawerState = currentDrawerState
+        scrollEndVelocity = nil
+
+        // Record the maximum top content inset that has even been observed.
+        // This is necessary to support `UINavigationController` drawers with
+        // Large Titles, since there is no any other way to query this
+        // information.
+        scrollMaxTopInset = max(scrollView.topInset, scrollMaxTopInset)
+    }
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        guard scrollView.isScrollEnabled,
+              !scrollViewNeedsTransitionAsDragEnds,
+              !scrollViewIsDecelerating,
+              scrollEndVelocity == nil
+            else { return }
+
+        let topInset = scrollView.topInset
+        let negativeVerticalOffset = -(scrollView.contentOffset.y + topInset)
+
+        // Intercept the content offset changes beyond the top content inset.
+        // The algorithm is aware of dynamic content inset adjustments induced
+        // by the Navigation Bar Large Title Mode since iOS 11.0.
+        let shouldOverrideScroll = scrollStartDrawerState != currentDrawerState
+            || (scrollMaxTopInset == topInset && negativeVerticalOffset > 0.0)
+            || currentDrawerState.isTransitioning
+
+        if shouldOverrideScroll {
+            self.applyTranslationY(negativeVerticalOffset)
+            scrollView.contentOffset.y = -topInset
+
+            // Detect and animate any top content inset change due to its parent
+            // `UINavigationController` (if any) moving away from (0, 0) in
+            // screen coordinates.
+            let delta = topInset - scrollView.topInset
+
+            UIView.animate(withDuration: 0.1) {
+                self.applyTranslationY(max(delta, 0.0))
+                self.presentedViewController.view.layoutIfNeeded()
+            }
+        }
+    }
+
+    func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+        if scrollStartDrawerState != currentDrawerState {
+            scrollEndVelocity = velocity
+            scrollViewNeedsTransitionAsDragEnds = true
+            targetContentOffset.pointee = scrollView.contentOffset
+        }
+    }
+
+    func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        scrollViewIsDecelerating = decelerate
+
+        func cleanup() {
+            scrollEndVelocity = nil
+            scrollViewNeedsTransitionAsDragEnds = false
+        }
+
+        guard let velocity = scrollEndVelocity, scrollViewNeedsTransitionAsDragEnds else {
+            cleanup()
+            return
+        }
+
+        let drawerSpeedY = -velocity.y / containerViewHeight
+        let endingState = GeometryEvaluator.nextStateFrom(currentState: currentDrawerState,
+                                                          speedY: drawerSpeedY,
+                                                          drawerPartialHeight: drawerPartialHeight,
+                                                          containerViewHeight: containerViewHeight,
+                                                          configuration: configuration)
+
+        animateTransition(
+            to: endingState,
+            animateAlongside: {
+                self.presentedViewController.view.layoutIfNeeded()
+                scrollView.contentOffset.y = -scrollView.topInset
+                scrollView.flashScrollIndicators()
+            },
+            completion: cleanup
+        )
+    }
+
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        scrollViewIsDecelerating = false
+    }
+}
+
+private extension DrawerState {
+    var isTransitioning: Bool {
+        switch self {
+        case .transitioning:
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+private extension UIScrollView {
+    var topInset: CGFloat {
+        if #available(iOS 11.0, *) {
+            return adjustedContentInset.top
+        } else {
+            return contentInset.top
+        }
+    }
+}

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Setup.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Setup.swift
@@ -60,7 +60,7 @@ extension PresentationController {
 
 extension PresentationController {
     func setupDrawerDragRecogniser() {
-        guard drawerDragGR == nil && isDrawerDraggable else { return }
+        guard drawerDragGR == nil, isDrawerDraggable else { return }
         let panGesture = UIPanGestureRecognizer(target: self,
                                                 action: #selector(handleDrawerDrag))
         presentedView?.addGestureRecognizer(panGesture)

--- a/DrawerKit/DrawerKit/Internal API/PresentationController.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController.swift
@@ -23,13 +23,16 @@ final class PresentationController: UIPresentationController {
     var startingDrawerStateForDrag: DrawerState?
 
     var pullToDismissManager: PullToDismissManager?
+
     weak var scrollViewForPullToDismiss: UIScrollView? {
-        didSet {
+        willSet {
             if let manager = pullToDismissManager {
                 scrollViewForPullToDismiss?.delegate = manager.delegate
                 pullToDismissManager = nil
             }
+        }
 
+        didSet {
             if let scrollView = scrollViewForPullToDismiss {
                 pullToDismissManager = PullToDismissManager(delegate: scrollView.delegate,
                                                             presentationController: self)

--- a/DrawerKit/DrawerKit/Public API/Protocols/DrawerPresentationControlling.swift
+++ b/DrawerKit/DrawerKit/Public API/Protocols/DrawerPresentationControlling.swift
@@ -1,0 +1,22 @@
+public protocol DrawerPresentationControlling: class {
+    /// The scroll view to enable pull-to-dismiss on the drawer. It can be
+    /// placed at any origin of any arbitrary size.
+    ///
+    /// The drawer materialises pull-to-dismiss by installing an internal
+    /// controller as the scroll view delegate, and manipulating the vertical
+    /// content offset.
+    ///
+    /// - important: If the navigation bar is non-translucent, it is strongly
+    ///              recommended _not to use_ the `coversFullscreen` full
+    ///              expansion behavior due to interoperability issues with the
+    ///              obscure `UINavigationBar` Large Title mechanism.
+    ///
+    /// - note: The drawer presentation controller does not retain the view.
+    var scrollViewForPullToDismiss: UIScrollView? { get set }
+}
+
+extension UIViewController {
+    public var drawerPresentationController: DrawerPresentationControlling? {
+        return presentationController as? DrawerPresentationControlling
+    }
+}

--- a/DrawerKitDemo/DrawerKitDemo.xcodeproj/project.pbxproj
+++ b/DrawerKitDemo/DrawerKitDemo.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9AB81C482076E73800C7A595 /* PresentedNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AB81C472076E73800C7A595 /* PresentedNavigationController.swift */; };
 		CBBA2D3A1F8E807400E0137F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBBA2D391F8E807400E0137F /* AppDelegate.swift */; };
 		CBBA2D411F8E807400E0137F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CBBA2D3F1F8E807400E0137F /* Main.storyboard */; };
 		CBBA2D431F8E807400E0137F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CBBA2D421F8E807400E0137F /* Assets.xcassets */; };
@@ -44,6 +45,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		9AB81C472076E73800C7A595 /* PresentedNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentedNavigationController.swift; sourceTree = "<group>"; };
 		CBBA2D361F8E807400E0137F /* DrawerKitDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DrawerKitDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CBBA2D391F8E807400E0137F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CBBA2D401F8E807400E0137F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -103,6 +105,7 @@
 				CBBA2D391F8E807400E0137F /* AppDelegate.swift */,
 				CBBA2D6B1F8E83E300E0137F /* PresenterViewController.swift */,
 				CBBA2D6E1F8E83E300E0137F /* PresentedViewController.swift */,
+				9AB81C472076E73800C7A595 /* PresentedNavigationController.swift */,
 				CBBA2D6D1F8E83E300E0137F /* PresentedView.swift */,
 				CBBA2D421F8E807400E0137F /* Assets.xcassets */,
 				CBBA2D6A1F8E839200E0137F /* Storyboards */,
@@ -180,7 +183,7 @@
 				TargetAttributes = {
 					CBBA2D351F8E807300E0137F = {
 						CreatedOnToolsVersion = 9.0;
-						ProvisioningStyle = Manual;
+						ProvisioningStyle = Automatic;
 					};
 					D8AC28F41F965EFC0085F252 = {
 						CreatedOnToolsVersion = 9.0;
@@ -235,6 +238,7 @@
 			files = (
 				CBBA2D3A1F8E807400E0137F /* AppDelegate.swift in Sources */,
 				CBBA2D721F8E83E300E0137F /* PresentedViewController.swift in Sources */,
+				9AB81C482076E73800C7A595 /* PresentedNavigationController.swift in Sources */,
 				CBBA2D711F8E83E300E0137F /* PresentedView.swift in Sources */,
 				CBBA2D6F1F8E83E300E0137F /* PresenterViewController.swift in Sources */,
 			);
@@ -389,11 +393,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_STYLE = Manual;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = DrawerKitDemo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.babylonhealth.DrawerKitDemo;
+				PRODUCT_BUNDLE_IDENTIFIER = com.babylonpartners.DrawerKitDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 4.0;
@@ -405,11 +410,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_STYLE = Manual;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = DrawerKitDemo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.babylonhealth.DrawerKitDemo;
+				PRODUCT_BUNDLE_IDENTIFIER = com.babylonpartners.DrawerKitDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 4.0;

--- a/DrawerKitDemo/DrawerKitDemo/PresentedNavigationController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresentedNavigationController.swift
@@ -1,0 +1,31 @@
+import UIKit
+import DrawerKit
+
+class PresentedNavigationController: UINavigationController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        delegate = self
+    }
+}
+
+extension PresentedNavigationController: DrawerAnimationParticipant {
+    var drawerAnimationActions: DrawerAnimationActions {
+        return (topViewController as? DrawerAnimationParticipant)?.drawerAnimationActions
+            ?? DrawerAnimationActions()
+    }
+}
+
+extension PresentedNavigationController: DrawerPresentable {
+    var heightOfPartiallyExpandedDrawer: CGFloat {
+        return (topViewController as? DrawerPresentable)?.heightOfPartiallyExpandedDrawer ?? 0.0
+    }
+}
+
+extension PresentedNavigationController: UINavigationControllerDelegate {
+    func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
+        if let viewController = viewController as? PresentedViewController {
+            drawerPresentationController?.scrollViewForPullToDismiss = viewController.presentedView
+        }
+    }
+}

--- a/DrawerKitDemo/DrawerKitDemo/PresentedView.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresentedView.swift
@@ -1,7 +1,6 @@
 import UIKit
 
-class PresentedView: UIView {
-    @IBOutlet weak var titleLabel: UILabel!
+class PresentedView: UIScrollView {
     @IBOutlet weak var bodyLabel: UILabel!
     @IBOutlet weak var dismissButton: UIButton!
     @IBOutlet weak var dividerView: UIView!
@@ -10,13 +9,11 @@ class PresentedView: UIView {
 
 extension PresentedView {
     func prepareCollapsedToPartiallyExpanded() {
-        titleLabel.alpha = 0
         bodyLabel.transform = CGAffineTransform(scaleX: 0.01, y: 0.01)
         dismissButton.alpha = 0
     }
 
     func animateAlongCollapsedToPartiallyExpanded() {
-        titleLabel.alpha = 1
         bodyLabel.transform = .identity
         dismissButton.alpha = 1
     }

--- a/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
@@ -26,16 +26,17 @@ class PresentedViewController: UIViewController {
     @IBAction func unwindFromModal(with segue: UIStoryboardSegue) {}
 }
 
-extension PresentedViewController: UIScrollViewDelegate {
-    func viewForZooming(in scrollView: UIScrollView) -> UIView? {
-        return (view as? PresentedView)?.imageView
-    }
-}
+extension PresentedViewController: UIScrollViewDelegate {}
 
 extension PresentedViewController: DrawerPresentable {
     var heightOfPartiallyExpandedDrawer: CGFloat {
         guard let view = self.view as? PresentedView else { return 0 }
-        return view.dividerView.frame.origin.y
+
+        if #available(iOS 11, *) {
+            return view.dividerView.frame.origin.y + view.adjustedContentInset.top
+        } else {
+            return view.dividerView.frame.origin.y + topLayoutGuide.length
+        }
     }
 }
 

--- a/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
@@ -12,7 +12,7 @@ class PresenterViewController: UIViewController, DrawerCoordinating {
 private extension PresenterViewController {
     func doModalPresentation() {
         guard let vc = storyboard?.instantiateViewController(withIdentifier: "presented")
-            as? PresentedViewController else { return }
+            as? PresentedNavigationController else { return }
 
         // you can provide the configuration values in the initialiser...
         var configuration = DrawerConfiguration(/* ..., ..., ..., */)

--- a/DrawerKitDemo/DrawerKitDemo/Storyboards/Base.lproj/Main.storyboard
+++ b/DrawerKitDemo/DrawerKitDemo/Storyboards/Base.lproj/Main.storyboard
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="uBw-Sr-LpF">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="uBw-Sr-LpF">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -59,47 +59,55 @@
             </objects>
             <point key="canvasLocation" x="-5633" y="-3600"/>
         </scene>
+        <!--Presented Navigation Controller-->
+        <scene sceneID="EHc-yS-Lt4">
+            <objects>
+                <navigationController storyboardIdentifier="presented" id="6Kj-wy-xhv" customClass="PresentedNavigationController" customModule="DrawerKitDemo" customModuleProvider="target" sceneMemberID="viewController">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="v9q-fe-zD1">
+                        <rect key="frame" x="0.0" y="20" width="375" height="96"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="9a9-ft-1GT" kind="relationship" relationship="rootViewController" id="Yiu-80-EYj"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="sSD-pu-cFe" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-4982" y="-3600"/>
+        </scene>
         <!--Presented-->
         <scene sceneID="LaC-qO-hbN">
             <objects>
-                <viewController storyboardIdentifier="presented" title="Presented" id="9a9-ft-1GT" customClass="PresentedViewController" customModule="DrawerKitDemo" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController title="Presented" id="9a9-ft-1GT" customClass="PresentedViewController" customModule="DrawerKitDemo" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="bMW-fV-gMF"/>
-                        <viewControllerLayoutGuide type="bottom" id="gXZ-qi-Dx3"/>
+                        <viewControllerLayoutGuide type="top" id="zIK-Ww-48k"/>
+                        <viewControllerLayoutGuide type="bottom" id="ogW-No-fLf"/>
                     </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="tAJ-xI-Qxr" customClass="PresentedView" customModule="DrawerKitDemo" customModuleProvider="target">
+                    <scrollView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" alwaysBounceVertical="YES" id="3AF-uf-HK5" customClass="PresentedView" customModule="DrawerKitDemo" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Saturn" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jth-UI-73K">
-                                <rect key="frame" x="148" y="28" width="79" height="30"/>
-                                <color key="tintColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
-                                <accessibility key="accessibilityConfiguration" identifier="drawerTitle"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="25"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Swipe up for more details!" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="300" translatesAutoresizingMaskIntoConstraints="NO" id="69I-et-UOX">
-                                <rect key="frame" x="87.5" y="68" width="200" height="21"/>
-                                <color key="tintColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="Swipe up for more details!" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="300" translatesAutoresizingMaskIntoConstraints="NO" id="C6l-MP-6CN">
+                                <rect key="frame" x="88" y="16" width="199.5" height="20.5"/>
+                                <color key="tintColor" white="0.33333333329999998" alpha="1" colorSpace="calibratedWhite"/>
                                 <accessibility key="accessibilityConfiguration" identifier="drawerDescription"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dEa-Pl-yQz">
-                                <rect key="frame" x="0.0" y="189" width="375" height="1"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="e9r-kz-Vw9">
+                                <rect key="frame" x="38" y="126.5" width="300" height="1"/>
                                 <color key="backgroundColor" red="1" green="0.039765733839999998" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="1" id="swW-cT-thv"/>
+                                    <constraint firstAttribute="height" constant="1" id="pqF-UO-bTE"/>
                                 </constraints>
                             </view>
-                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qPD-ym-Fa5">
-                                <rect key="frame" x="165" y="114" width="44" height="44"/>
+                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7Lf-1M-NuW">
+                                <rect key="frame" x="165" y="66.5" width="44" height="44"/>
                                 <accessibility key="accessibilityConfiguration" identifier="drawerClose"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="44" id="U7N-Zz-5cE"/>
-                                    <constraint firstAttribute="width" constant="44" id="glj-Cq-BkG"/>
+                                    <constraint firstAttribute="width" constant="44" id="dmi-Qw-ahk"/>
+                                    <constraint firstAttribute="height" constant="44" id="twD-XV-Ow1"/>
                                 </constraints>
                                 <state key="normal" image="close"/>
                                 <userDefinedRuntimeAttributes>
@@ -108,69 +116,57 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                                 <connections>
-                                    <action selector="dismissButtonTapped" destination="9a9-ft-1GT" eventType="touchUpInside" id="iCd-lF-dg5"/>
+                                    <action selector="dismissButtonTapped" destination="9a9-ft-1GT" eventType="touchUpInside" id="hN9-Dj-hJO"/>
                                 </connections>
                             </button>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" alwaysBounceHorizontal="YES" minimumZoomScale="0.25" maximumZoomScale="1.5" translatesAutoresizingMaskIntoConstraints="NO" id="Ojr-aM-v38">
-                                <rect key="frame" x="26" y="210" width="323" height="437"/>
-                                <subviews>
-                                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Saturn" translatesAutoresizingMaskIntoConstraints="NO" id="rpy-pk-bsr">
-                                        <rect key="frame" x="0.0" y="0.0" width="323" height="437"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="saturnImage"/>
-                                    </imageView>
-                                </subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="750" image="Saturn" translatesAutoresizingMaskIntoConstraints="NO" id="xSt-L4-9Fg">
+                                <rect key="frame" x="38" y="157" width="300" height="1000"/>
+                                <accessibility key="accessibilityConfiguration" identifier="saturnImage"/>
                                 <constraints>
-                                    <constraint firstAttribute="bottom" secondItem="rpy-pk-bsr" secondAttribute="bottom" id="2OE-UK-kX2"/>
-                                    <constraint firstItem="rpy-pk-bsr" firstAttribute="leading" secondItem="Ojr-aM-v38" secondAttribute="leading" id="3c8-ZF-90Z"/>
-                                    <constraint firstAttribute="trailing" secondItem="rpy-pk-bsr" secondAttribute="trailing" id="IIZ-hA-Ypd"/>
-                                    <constraint firstItem="rpy-pk-bsr" firstAttribute="top" secondItem="Ojr-aM-v38" secondAttribute="top" id="N3j-C7-1ko"/>
-                                    <constraint firstItem="rpy-pk-bsr" firstAttribute="centerY" secondItem="Ojr-aM-v38" secondAttribute="centerY" id="r1p-EP-BFz"/>
-                                    <constraint firstItem="rpy-pk-bsr" firstAttribute="centerX" secondItem="Ojr-aM-v38" secondAttribute="centerX" id="sVA-Y6-Pye"/>
+                                    <constraint firstAttribute="height" constant="1000" id="wQl-br-6Sy"/>
                                 </constraints>
-                                <connections>
-                                    <outlet property="delegate" destination="9a9-ft-1GT" id="Ta0-1G-Esp"/>
-                                </connections>
-                            </scrollView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="detailDisclosure" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ztp-Cf-a4s">
-                                <rect key="frame" x="235" y="32" width="22" height="22"/>
+                            </imageView>
+                        </subviews>
+                        <color key="backgroundColor" red="0.99953407049999998" green="0.98835557699999999" blue="0.47265523669999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="C6l-MP-6CN" firstAttribute="centerX" secondItem="3AF-uf-HK5" secondAttribute="centerX" id="25K-vs-cMC"/>
+                            <constraint firstItem="xSt-L4-9Fg" firstAttribute="top" secondItem="e9r-kz-Vw9" secondAttribute="bottom" constant="30" id="2lw-Ix-M4E"/>
+                            <constraint firstItem="xSt-L4-9Fg" firstAttribute="centerX" secondItem="3AF-uf-HK5" secondAttribute="centerX" id="FUW-LT-c7z"/>
+                            <constraint firstItem="e9r-kz-Vw9" firstAttribute="top" secondItem="7Lf-1M-NuW" secondAttribute="bottom" constant="16" id="JbA-n2-hck"/>
+                            <constraint firstItem="7Lf-1M-NuW" firstAttribute="top" secondItem="C6l-MP-6CN" secondAttribute="bottom" constant="30" id="S9s-Ng-i2I"/>
+                            <constraint firstItem="7Lf-1M-NuW" firstAttribute="centerX" secondItem="3AF-uf-HK5" secondAttribute="centerX" id="Smq-N0-6iH"/>
+                            <constraint firstItem="e9r-kz-Vw9" firstAttribute="centerX" secondItem="3AF-uf-HK5" secondAttribute="centerX" id="UcO-eP-gid"/>
+                            <constraint firstItem="e9r-kz-Vw9" firstAttribute="width" secondItem="3AF-uf-HK5" secondAttribute="width" multiplier="0.8" id="ceX-dh-gVc"/>
+                            <constraint firstItem="xSt-L4-9Fg" firstAttribute="bottom" secondItem="3AF-uf-HK5" secondAttribute="bottom" constant="-30" id="qCW-gn-7vZ"/>
+                            <constraint firstItem="xSt-L4-9Fg" firstAttribute="width" secondItem="3AF-uf-HK5" secondAttribute="width" multiplier="0.8" id="xCf-Wo-7fd"/>
+                            <constraint firstItem="C6l-MP-6CN" firstAttribute="top" secondItem="3AF-uf-HK5" secondAttribute="top" constant="16" id="xkb-6d-Lro"/>
+                        </constraints>
+                        <connections>
+                            <outlet property="bodyLabel" destination="C6l-MP-6CN" id="vYV-7n-aGT"/>
+                            <outlet property="delegate" destination="9a9-ft-1GT" id="gvi-XX-IQE"/>
+                            <outlet property="dismissButton" destination="7Lf-1M-NuW" id="ltS-4X-330"/>
+                            <outlet property="dividerView" destination="e9r-kz-Vw9" id="prT-nI-s4S"/>
+                            <outlet property="imageView" destination="xSt-L4-9Fg" id="mdN-MF-a8z"/>
+                        </connections>
+                    </scrollView>
+                    <navigationItem key="navigationItem" title="Saturn" largeTitleDisplayMode="always" id="2LO-yG-177">
+                        <barButtonItem key="rightBarButtonItem" style="plain" id="uyM-3X-Zhf">
+                            <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="detailDisclosure" lineBreakMode="middleTruncation" id="Ztp-Cf-a4s">
+                                <rect key="frame" x="337" y="11" width="22" height="22"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <connections>
                                     <segue destination="ILn-GS-avA" kind="presentation" id="Dds-Br-1fx"/>
                                 </connections>
                             </button>
-                        </subviews>
-                        <color key="backgroundColor" red="0.98065741760000003" green="1" blue="0.90980392160000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                        <constraints>
-                            <constraint firstItem="69I-et-UOX" firstAttribute="top" secondItem="Jth-UI-73K" secondAttribute="bottom" constant="10" id="5I8-eE-iaZ"/>
-                            <constraint firstItem="69I-et-UOX" firstAttribute="centerX" secondItem="tAJ-xI-Qxr" secondAttribute="centerX" id="95D-ht-lrm"/>
-                            <constraint firstItem="Ojr-aM-v38" firstAttribute="top" secondItem="dEa-Pl-yQz" secondAttribute="bottom" constant="20" id="Dgd-aQ-agb"/>
-                            <constraint firstItem="dEa-Pl-yQz" firstAttribute="top" secondItem="69I-et-UOX" secondAttribute="bottom" constant="100" id="Eai-cn-LDj"/>
-                            <constraint firstItem="Ztp-Cf-a4s" firstAttribute="leading" secondItem="Jth-UI-73K" secondAttribute="trailing" constant="8" id="Pr8-hl-LaR"/>
-                            <constraint firstItem="dEa-Pl-yQz" firstAttribute="leading" secondItem="tAJ-xI-Qxr" secondAttribute="leading" id="Vcw-46-NLg"/>
-                            <constraint firstItem="Jth-UI-73K" firstAttribute="top" secondItem="tAJ-xI-Qxr" secondAttribute="top" constant="28" id="aH2-1L-AcL"/>
-                            <constraint firstItem="Ojr-aM-v38" firstAttribute="leading" secondItem="tAJ-xI-Qxr" secondAttribute="leadingMargin" constant="10" id="cWU-AN-kgF"/>
-                            <constraint firstItem="qPD-ym-Fa5" firstAttribute="top" secondItem="69I-et-UOX" secondAttribute="bottom" constant="25" id="cpO-2w-akW"/>
-                            <constraint firstAttribute="trailing" secondItem="dEa-Pl-yQz" secondAttribute="trailing" id="gI5-Vo-Tk3"/>
-                            <constraint firstItem="Jth-UI-73K" firstAttribute="centerX" secondItem="tAJ-xI-Qxr" secondAttribute="centerX" id="hN7-u7-BLQ"/>
-                            <constraint firstItem="Ztp-Cf-a4s" firstAttribute="centerY" secondItem="Jth-UI-73K" secondAttribute="centerY" id="m1M-EE-Co9"/>
-                            <constraint firstAttribute="bottomMargin" secondItem="Ojr-aM-v38" secondAttribute="bottom" constant="20" id="r5Q-A1-OUj"/>
-                            <constraint firstItem="qPD-ym-Fa5" firstAttribute="centerX" secondItem="tAJ-xI-Qxr" secondAttribute="centerX" id="sgV-nk-lFF"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="Ojr-aM-v38" secondAttribute="trailing" constant="10" id="tkz-7e-SmV"/>
-                        </constraints>
-                        <connections>
-                            <outlet property="bodyLabel" destination="69I-et-UOX" id="yM2-QU-7fi"/>
-                            <outlet property="dismissButton" destination="qPD-ym-Fa5" id="vT0-hE-mwT"/>
-                            <outlet property="dividerView" destination="dEa-Pl-yQz" id="aF0-jd-cMU"/>
-                            <outlet property="imageView" destination="rpy-pk-bsr" id="JPN-4k-Tmo"/>
-                            <outlet property="titleLabel" destination="Jth-UI-73K" id="THa-a8-8sV"/>
-                        </connections>
-                    </view>
+                        </barButtonItem>
+                    </navigationItem>
                     <connections>
-                        <outlet property="presentedView" destination="tAJ-xI-Qxr" id="N57-5D-1ic"/>
+                        <outlet property="presentedView" destination="3AF-uf-HK5" id="Kua-ZM-PBs"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="mjN-SN-YOS" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-4889" y="-3600"/>
+            <point key="canvasLocation" x="-4258.3999999999996" y="-3600.4497751124441"/>
         </scene>
         <!--View Controller-->
         <scene sceneID="hN9-WT-acc">
@@ -206,7 +202,7 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="pVR-K0-1GK" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <exit id="qRR-E6-YWn" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
-            <point key="canvasLocation" x="-4071.1999999999998" y="-3600.4497751124441"/>
+            <point key="canvasLocation" x="-3471" y="-3600"/>
         </scene>
     </scenes>
     <resources>

--- a/DrawerKitDemo/DrawerKitDemoUITests/DrawerKitDemoUITests.swift
+++ b/DrawerKitDemo/DrawerKitDemoUITests/DrawerKitDemoUITests.swift
@@ -3,7 +3,7 @@ import XCTest
 class DrawerKitDemoUITests: XCTestCase {
     
     var app: XCUIApplication!
-    let drawerY: CGFloat = 500.0
+    let transitionTimeout: TimeInterval = 1.0
     
     enum ElementState: String {
         case exists = "exists == true"
@@ -13,7 +13,7 @@ class DrawerKitDemoUITests: XCTestCase {
     fileprivate enum Identifiers {
         static let mainCanvas = "mainCanvas"
         static let closeButton = "drawerClose"
-        static let drawerTitle = "drawerTitle"
+        static let drawerDescription = "drawerDescription"
         static let drawerImage = "saturnImage"
     }
     
@@ -57,13 +57,13 @@ class DrawerKitDemoUITests: XCTestCase {
         let mainCanvase = app.buttons[Identifiers.mainCanvas]
         mainCanvase.tap()
         
-        let drawer = app.staticTexts[Identifiers.drawerTitle].firstMatch
+        let drawer = app.staticTexts[Identifiers.drawerDescription].firstMatch
         let start = drawer.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
         let end = mainCanvase.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.1))
         start.press(forDuration: 0.05, thenDragTo: end)
         XCTAssertTrue(isDrawerFullyOpen())
-        
-        drawer.swipeDown()
+
+        end.press(forDuration: 0.05, thenDragTo: start)
         XCTAssertFalse(isDrawerFullyOpen())
     }
     
@@ -71,7 +71,7 @@ class DrawerKitDemoUITests: XCTestCase {
         let mainCanvase = app.buttons[Identifiers.mainCanvas]
         mainCanvase.tap()
         
-        let drawer = app.staticTexts[Identifiers.drawerTitle]
+        let drawer = app.staticTexts[Identifiers.drawerDescription]
         drawer.swipeUp()
 
         let closeButton = app.buttons[Identifiers.closeButton]
@@ -81,8 +81,8 @@ class DrawerKitDemoUITests: XCTestCase {
     }
     
     private func isDrawerOpen() -> Bool {
-        let drawer = app.staticTexts[Identifiers.drawerTitle]
-        if tryWaitFor(element: drawer, withState: .exists) {
+        let drawer = app.staticTexts[Identifiers.drawerDescription]
+        if tryWaitFor(element: drawer, withState: .exists, waiting: transitionTimeout) {
             return drawer.isHittable
         } else {
             return false
@@ -91,8 +91,8 @@ class DrawerKitDemoUITests: XCTestCase {
     
     private func isDrawerFullyOpen() -> Bool {
         let image = app.images[Identifiers.drawerImage]
-        if tryWaitFor(element: image, withState: .exists) {
-            return app.images[Identifiers.drawerImage].frame.origin.y < drawerY
+        if tryWaitFor(element: image, withState: .exists, waiting: transitionTimeout) {
+            return app.images[Identifiers.drawerImage].frame.minY < app.frame.maxY
         } else {
             return false
         }


### PR DESCRIPTION
Drawer Content VCs may enable pull to dismiss simply by setting `scrollViewForPullToDismiss` on the drawer presentation controller. Supports iOS 11 Large Title.

![pull-to-dismiss](https://user-images.githubusercontent.com/11806295/38394204-7a9aa336-3925-11e8-825d-bb8abd8b6009.gif)
