### PR TITLE
Defer view controller dismissal caused by drawer dismissal taps.

### DIFF
--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Gestures.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Gestures.swift
@@ -15,7 +15,7 @@ extension PresentationController {
         guard tapY < currentDrawerY else { return }
         NotificationCenter.default.post(notification: DrawerNotification.drawerExteriorTapped)
         tapGesture.isEnabled = false
-        presentedViewController.dismiss(animated: true)
+        animateTransition(to: .collapsed)
     }
 
     @objc func handleDrawerDrag() {


### PR DESCRIPTION
Instead of dismissing the drawer VC as we tap on the drawer, utilise `animateTransition(to:)` which would first animate the drawer to its collapsed state _before_ dismissing the VC.

This allows status bar appearance settings of drawer presentables, if changed, to be respected properly in this particular scenario.