### PR TITLE
Configurable initial state and collapsed state height

### DIFF
--- a/DrawerKit/DrawerKit/Internal API/GeometryEvaluator.swift
+++ b/DrawerKit/DrawerKit/Internal API/GeometryEvaluator.swift
@@ -79,7 +79,7 @@ extension GeometryEvaluator {
                             clampToNearest: Bool = false) -> DrawerState {
         let drawerFullY = configuration.fullExpansionBehaviour.drawerFullY
         if smallerThanOrEqual(positionY, drawerFullY) { return .fullyExpanded }
-        if greaterThanOrEqual(positionY, containerViewHeight) { return .collapsed }
+        if greaterThanOrEqual(positionY, containerViewHeight) { return .dismissed }
 
         let partialY = drawerPartialY(drawerPartialHeight: drawerPartialHeight,
                                       containerViewHeight: containerViewHeight)
@@ -105,7 +105,7 @@ extension GeometryEvaluator {
                                 containerViewHeight: CGFloat,
                                 drawerFullY: CGFloat) -> CGFloat {
         switch state {
-        case .collapsed:
+        case .dismissed:
             return drawerCollapsedY(drawerCollapsedHeight: drawerCollapsedHeight,
                                     containerViewHeight: containerViewHeight)
         case .partiallyExpanded:
@@ -158,25 +158,25 @@ extension GeometryEvaluator {
         // === RETURN LOGIC STARTS HERE === //
 
         if isMovingUpQuickly { return .fullyExpanded }
-        if isMovingDownQuickly { return .collapsed }
+        if isMovingDownQuickly { return .dismissed }
 
         if isAboveUpperMark {
             if isMovingUp || isNotMoving {
                 return .fullyExpanded
             } else { // isMovingDown
                 let inStages = supportsPartialExpansion && dismissesInStages
-                return inStages ? .partiallyExpanded : .collapsed
+                return inStages ? .partiallyExpanded : .dismissed
             }
         }
 
         if isAboveLowerMark {
             if isMovingDown {
-                return .collapsed
+                return .dismissed
             } else { // isMovingUp || isNotMoving
                 return (supportsPartialExpansion ? .partiallyExpanded : .fullyExpanded)
             }
         }
 
-        return .collapsed
+        return .dismissed
     }
 }

--- a/DrawerKit/DrawerKit/Internal API/GeometryEvaluator.swift
+++ b/DrawerKit/DrawerKit/Internal API/GeometryEvaluator.swift
@@ -106,6 +106,8 @@ extension GeometryEvaluator {
                                 drawerFullY: CGFloat) -> CGFloat {
         switch state {
         case .dismissed:
+            return containerViewHeight
+        case .collapsed:
             return drawerCollapsedY(drawerCollapsedHeight: drawerCollapsedHeight,
                                     containerViewHeight: containerViewHeight)
         case .partiallyExpanded:
@@ -158,25 +160,29 @@ extension GeometryEvaluator {
         // === RETURN LOGIC STARTS HERE === //
 
         if isMovingUpQuickly { return .fullyExpanded }
-        if isMovingDownQuickly { return .dismissed }
+        if isMovingDownQuickly { return finalState(drawerCollapsedHeight: drawerCollapsedHeight, configuration: configuration) }
 
         if isAboveUpperMark {
             if isMovingUp || isNotMoving {
                 return .fullyExpanded
             } else { // isMovingDown
                 let inStages = supportsPartialExpansion && dismissesInStages
-                return inStages ? .partiallyExpanded : .dismissed
+                return inStages ? .partiallyExpanded : finalState(drawerCollapsedHeight: drawerCollapsedHeight, configuration: configuration)
             }
         }
 
         if isAboveLowerMark {
             if isMovingDown {
-                return .dismissed
+                return finalState(drawerCollapsedHeight: drawerCollapsedHeight, configuration: configuration)
             } else { // isMovingUp || isNotMoving
                 return (supportsPartialExpansion ? .partiallyExpanded : .fullyExpanded)
             }
         }
 
-        return .dismissed
+        return finalState(drawerCollapsedHeight: drawerCollapsedHeight, configuration: configuration)
+    }
+
+    private static func finalState(drawerCollapsedHeight: CGFloat, configuration: DrawerConfiguration) -> DrawerState {
+        return drawerCollapsedHeight > 0 && configuration.dismissesInStages ? .collapsed : .dismissed
     }
 }

--- a/DrawerKit/DrawerKit/Internal API/GeometryEvaluator.swift
+++ b/DrawerKit/DrawerKit/Internal API/GeometryEvaluator.swift
@@ -13,6 +13,18 @@ struct GeometryEvaluator {
         return containerViewHeight - partialH
     }
 
+    static func drawerCollapsedH(drawerCollapsedHeight: CGFloat,
+                               containerViewHeight: CGFloat) -> CGFloat {
+        return min(max(drawerCollapsedHeight, 0), containerViewHeight)
+    }
+
+    static func drawerCollapsedY(drawerCollapsedHeight: CGFloat,
+                               containerViewHeight: CGFloat) -> CGFloat {
+        let collapsedH = drawerCollapsedH(drawerCollapsedHeight: drawerCollapsedHeight,
+                                          containerViewHeight: containerViewHeight)
+        return containerViewHeight - collapsedH
+    }
+
     static func upperMarkY(drawerPartialHeight: CGFloat,
                            containerViewHeight: CGFloat,
                            configuration: DrawerConfiguration) -> CGFloat {
@@ -88,12 +100,14 @@ extension GeometryEvaluator {
     }
 
     static func drawerPositionY(for state: DrawerState,
+                                drawerCollapsedHeight: CGFloat,
                                 drawerPartialHeight: CGFloat,
                                 containerViewHeight: CGFloat,
                                 drawerFullY: CGFloat) -> CGFloat {
         switch state {
         case .collapsed:
-            return containerViewHeight
+            return drawerCollapsedY(drawerCollapsedHeight: drawerCollapsedHeight,
+                                    containerViewHeight: containerViewHeight)
         case .partiallyExpanded:
             return drawerPartialY(drawerPartialHeight: drawerPartialHeight,
                                   containerViewHeight: containerViewHeight)
@@ -106,6 +120,7 @@ extension GeometryEvaluator {
 
     static func nextStateFrom(currentState: DrawerState,
                               speedY: CGFloat,
+                              drawerCollapsedHeight: CGFloat,
                               drawerPartialHeight: CGFloat,
                               containerViewHeight: CGFloat,
                               configuration: DrawerConfiguration) -> DrawerState {
@@ -121,6 +136,7 @@ extension GeometryEvaluator {
         let drawerFullY = configuration.fullExpansionBehaviour.drawerFullY
 
         let positionY = drawerPositionY(for: currentState,
+                                        drawerCollapsedHeight: drawerCollapsedHeight,
                                         drawerPartialHeight: drawerPartialHeight,
                                         containerViewHeight: containerViewHeight,
                                         drawerFullY: drawerFullY)

--- a/DrawerKit/DrawerKit/Internal API/GeometryEvaluator.swift
+++ b/DrawerKit/DrawerKit/Internal API/GeometryEvaluator.swift
@@ -3,7 +3,7 @@ import UIKit
 struct GeometryEvaluator {
     static func drawerPartialH(drawerPartialHeight: CGFloat,
                                containerViewHeight: CGFloat) -> CGFloat {
-        return min(max(drawerPartialHeight, 0), containerViewHeight)
+        return min(max(0, drawerPartialHeight), containerViewHeight)
     }
 
     static func drawerPartialY(drawerPartialHeight: CGFloat,
@@ -15,7 +15,7 @@ struct GeometryEvaluator {
 
     static func drawerCollapsedH(drawerCollapsedHeight: CGFloat,
                                containerViewHeight: CGFloat) -> CGFloat {
-        return min(max(drawerCollapsedHeight, 0), containerViewHeight)
+        return min(max(0, drawerCollapsedHeight), containerViewHeight)
     }
 
     static func drawerCollapsedY(drawerCollapsedHeight: CGFloat,

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Animation.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Animation.swift
@@ -63,26 +63,26 @@ extension PresentationController {
         animator.addCompletion { endingPosition in
             if autoAnimatesDimming { self.handleView?.alpha = endingHandleViewAlpha }
 
-            let isStartingStateCollapsed = (startingState == .dismissed)
-            let isEndingStateCollapsed = (endingState == .dismissed)
+            let isStartingStateDismissed = (startingState == .dismissed)
+            let isEndingStateDismissed = (endingState == .dismissed)
 
             let shouldDismiss =
-                (isStartingStateCollapsed && endingPosition == .start) ||
-                    (isEndingStateCollapsed && endingPosition == .end)
+                (isStartingStateDismissed && endingPosition == .start) ||
+                    (isEndingStateDismissed && endingPosition == .end)
 
-            if shouldDismiss && self.drawerCollapsedHeight <= 0 {
+            if shouldDismiss {
                 self.presentedViewController.dismiss(animated: true)
             }
 
-            let isStartingStateCollapsedOrFullyExpanded =
+            let isStartingStateDismissedOrFullyExpanded =
                 (startingState == .dismissed || startingState == .fullyExpanded)
 
-            let isEndingStateCollapsedOrFullyExpanded =
+            let isEndingStateDismissedOrFullyExpanded =
                 (endingState == .dismissed || endingState == .fullyExpanded)
 
             let shouldSetCornerRadiusToZero =
-                (isEndingStateCollapsedOrFullyExpanded && endingPosition == .end) ||
-                (isStartingStateCollapsedOrFullyExpanded && endingPosition == .start)
+                (isStartingStateDismissedOrFullyExpanded && endingPosition == .end) ||
+                (isEndingStateDismissedOrFullyExpanded && endingPosition == .start)
 
             if maxCornerRadius != 0 && shouldSetCornerRadiusToZero {
                 self.currentDrawerCornerRadius = 0
@@ -125,17 +125,17 @@ extension PresentationController {
             self.currentDrawerCornerRadius = endingCornerRadius
         }
 
-        let isStartingStateCollapsedOrFullyExpanded =
+        let isStartingStateDismissedOrFullyExpanded =
             (startingState == .dismissed || startingState == .fullyExpanded)
 
-        let isEndingStateCollapsedOrFullyExpanded =
+        let isEndingStateDismissedOrFullyExpanded =
             (endingState == .dismissed || endingState == .fullyExpanded)
 
-        if isStartingStateCollapsedOrFullyExpanded || isEndingStateCollapsedOrFullyExpanded {
+        if isStartingStateDismissedOrFullyExpanded || isEndingStateDismissedOrFullyExpanded {
             animator.addCompletion { endingPosition in
                 let shouldSetCornerRadiusToZero =
-                    (isEndingStateCollapsedOrFullyExpanded && endingPosition == .end) ||
-                    (isStartingStateCollapsedOrFullyExpanded && endingPosition == .start)
+                    (isEndingStateDismissedOrFullyExpanded && endingPosition == .end) ||
+                    (isStartingStateDismissedOrFullyExpanded && endingPosition == .start)
                 if shouldSetCornerRadiusToZero {
                     self.currentDrawerCornerRadius = 0
                 }

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Animation.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Animation.swift
@@ -63,8 +63,8 @@ extension PresentationController {
         animator.addCompletion { endingPosition in
             if autoAnimatesDimming { self.handleView?.alpha = endingHandleViewAlpha }
 
-            let isStartingStateCollapsed = (startingState == .collapsed)
-            let isEndingStateCollapsed = (endingState == .collapsed)
+            let isStartingStateCollapsed = (startingState == .dismissed)
+            let isEndingStateCollapsed = (endingState == .dismissed)
 
             let shouldDismiss =
                 (isStartingStateCollapsed && endingPosition == .start) ||
@@ -75,10 +75,10 @@ extension PresentationController {
             }
 
             let isStartingStateCollapsedOrFullyExpanded =
-                (startingState == .collapsed || startingState == .fullyExpanded)
+                (startingState == .dismissed || startingState == .fullyExpanded)
 
             let isEndingStateCollapsedOrFullyExpanded =
-                (endingState == .collapsed || endingState == .fullyExpanded)
+                (endingState == .dismissed || endingState == .fullyExpanded)
 
             let shouldSetCornerRadiusToZero =
                 (isEndingStateCollapsedOrFullyExpanded && endingPosition == .end) ||
@@ -126,10 +126,10 @@ extension PresentationController {
         }
 
         let isStartingStateCollapsedOrFullyExpanded =
-            (startingState == .collapsed || startingState == .fullyExpanded)
+            (startingState == .dismissed || startingState == .fullyExpanded)
 
         let isEndingStateCollapsedOrFullyExpanded =
-            (endingState == .collapsed || endingState == .fullyExpanded)
+            (endingState == .dismissed || endingState == .fullyExpanded)
 
         if isStartingStateCollapsedOrFullyExpanded || isEndingStateCollapsedOrFullyExpanded {
             animator.addCompletion { endingPosition in

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Animation.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Animation.swift
@@ -70,7 +70,7 @@ extension PresentationController {
                 (isStartingStateCollapsed && endingPosition == .start) ||
                     (isEndingStateCollapsed && endingPosition == .end)
 
-            if shouldDismiss {
+            if shouldDismiss && self.drawerCollapsedHeight <= 0 {
                 self.presentedViewController.dismiss(animated: true)
             }
 

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Animation.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Animation.swift
@@ -162,12 +162,14 @@ extension PresentationController {
         let drawerFullY = configuration.fullExpansionBehaviour.drawerFullY
         let startingPositionY =
             GeometryEvaluator.drawerPositionY(for: startingState,
+                                              drawerCollapsedHeight: drawerCollapsedHeight,
                                               drawerPartialHeight: drawerPartialHeight,
                                               containerViewHeight: containerViewHeight,
                                               drawerFullY: drawerFullY)
 
         let endingPositionY =
             GeometryEvaluator.drawerPositionY(for: endingState,
+                                              drawerCollapsedHeight: drawerCollapsedHeight,
                                               drawerPartialHeight: drawerPartialHeight,
                                               containerViewHeight: containerViewHeight,
                                               drawerFullY: drawerFullY)

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Gestures.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Gestures.swift
@@ -34,6 +34,7 @@ extension PresentationController {
             let drawerSpeedY = panGesture.velocity(in: view).y / containerViewHeight
             let endingState = GeometryEvaluator.nextStateFrom(currentState: currentDrawerState,
                                                               speedY: drawerSpeedY,
+                                                              drawerCollapsedHeight: drawerCollapsedHeight,
                                                               drawerPartialHeight: drawerPartialHeight,
                                                               containerViewHeight: containerViewHeight,
                                                               configuration: configuration)

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Gestures.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Gestures.swift
@@ -15,7 +15,7 @@ extension PresentationController {
         guard tapY < currentDrawerY else { return }
         NotificationCenter.default.post(notification: DrawerNotification.drawerExteriorTapped)
         tapGesture.isEnabled = false
-        animateTransition(to: .collapsed)
+        self.presentedViewController.dismiss(animated: true)
     }
 
     @objc func handleDrawerDrag() {

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Gestures.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Gestures.swift
@@ -15,7 +15,7 @@ extension PresentationController {
         guard tapY < currentDrawerY else { return }
         NotificationCenter.default.post(notification: DrawerNotification.drawerExteriorTapped)
         tapGesture.isEnabled = false
-        self.presentedViewController.dismiss(animated: true)
+        animateTransition(to: .collapsed)
     }
 
     @objc func handleDrawerDrag() {

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Gestures.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Gestures.swift
@@ -15,7 +15,7 @@ extension PresentationController {
         guard tapY < currentDrawerY else { return }
         NotificationCenter.default.post(notification: DrawerNotification.drawerExteriorTapped)
         tapGesture.isEnabled = false
-        animateTransition(to: .collapsed)
+        animateTransition(to: .dismissed)
     }
 
     @objc func handleDrawerDrag() {

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Properties.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Properties.swift
@@ -25,6 +25,18 @@ extension PresentationController {
                                                 containerViewHeight: containerViewHeight)
     }
 
+    var drawerCollapsedHeight: CGFloat {
+        guard let presentedVC = presentedViewController as? DrawerPresentable else { return 0 }
+        let drawerCollapsedH = presentedVC.heightOfCollapsedDrawer
+        return GeometryEvaluator.drawerCollapsedH(drawerCollapsedHeight: drawerCollapsedH,
+                                                  containerViewHeight: containerViewHeight)
+    }
+
+    var drawerCollapsedY: CGFloat {
+        return GeometryEvaluator.drawerCollapsedY(drawerCollapsedHeight: drawerCollapsedHeight,
+                                                containerViewHeight: containerViewHeight)
+    }
+
     var upperMarkY: CGFloat {
         return GeometryEvaluator.upperMarkY(drawerPartialHeight: drawerPartialHeight,
                                             containerViewHeight: containerViewHeight,
@@ -49,6 +61,7 @@ extension PresentationController {
             let drawerFullY = configuration.fullExpansionBehaviour.drawerFullY
             currentDrawerY =
                 GeometryEvaluator.drawerPositionY(for: newValue,
+                                                  drawerCollapsedHeight: drawerCollapsedHeight,
                                                   drawerPartialHeight: drawerPartialHeight,
                                                   containerViewHeight: containerViewHeight,
                                                   drawerFullY: drawerFullY)
@@ -93,6 +106,7 @@ extension PresentationController {
             let drawerFullY = configuration.fullExpansionBehaviour.drawerFullY
             let positionY =
                 GeometryEvaluator.drawerPositionY(for: state,
+                                                  drawerCollapsedHeight: drawerCollapsedHeight,
                                                   drawerPartialHeight: drawerPartialHeight,
                                                   containerViewHeight: containerViewHeight,
                                                   drawerFullY: drawerFullY)
@@ -115,6 +129,7 @@ extension PresentationController {
 
         let positionY =
             GeometryEvaluator.drawerPositionY(for: state,
+                                              drawerCollapsedHeight: drawerCollapsedHeight,
                                               drawerPartialHeight: drawerPartialHeight,
                                               containerViewHeight: containerViewHeight,
                                               drawerFullY: drawerFullY)

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+PullToDismiss.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+PullToDismiss.swift
@@ -105,6 +105,7 @@ final class PullToDismissManager: NSObject, UIScrollViewDelegate {
         let drawerSpeedY = -velocity.y / presentationController.containerViewHeight
         let endingState = GeometryEvaluator.nextStateFrom(currentState: presentationController.currentDrawerState,
                                                           speedY: drawerSpeedY,
+                                                          drawerCollapsedHeight: presentationController.drawerCollapsedHeight,
                                                           drawerPartialHeight: presentationController.drawerPartialHeight,
                                                           containerViewHeight: presentationController.containerViewHeight,
                                                           configuration: presentationController.configuration)

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Utilities.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Utilities.swift
@@ -22,7 +22,7 @@ func greaterThanOrEqual(_ lhs: CGFloat, _ rhs: CGFloat) -> Bool {
 extension DrawerState {
     public static func ==(lhs: DrawerState, rhs: DrawerState) -> Bool {
         switch (lhs, rhs) {
-        case (.collapsed, .collapsed),
+        case (.dismissed, .dismissed),
              (.partiallyExpanded, .partiallyExpanded),
              (.fullyExpanded, .fullyExpanded):
             return true

--- a/DrawerKit/DrawerKit/Internal API/PresentationController.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController.swift
@@ -82,6 +82,7 @@ extension PresentationController {
                           withParentContainerSize: containerViewSize)
         let drawerFullY = configuration.fullExpansionBehaviour.drawerFullY
         frame.origin.y = GeometryEvaluator.drawerPositionY(for: targetDrawerState,
+                                                           drawerCollapsedHeight: drawerCollapsedHeight,
                                                            drawerPartialHeight: drawerPartialHeight,
                                                            containerViewHeight: containerViewHeight,
                                                            drawerFullY: drawerFullY)

--- a/DrawerKit/DrawerKit/Internal API/PresentationController.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController.swift
@@ -66,7 +66,7 @@ final class PresentationController: UIPresentationController {
 
         if let scrollView = scrollViewForPullToDismiss, let manager = pullToDismissManager {
             switch targetDrawerState {
-            case .partiallyExpanded, .collapsed:
+            case .partiallyExpanded, .dismissed:
                 scrollView.isScrollEnabled = false
             case .transitioning, .fullyExpanded:
                 scrollView.isScrollEnabled = !manager.scrollViewNeedsTransitionAsDragEnds
@@ -114,7 +114,7 @@ extension PresentationController {
     }
 
     override func dismissalTransitionWillBegin() {
-        addCornerRadiusAnimationEnding(at: .collapsed)
+        addCornerRadiusAnimationEnding(at: .dismissed)
         enableDrawerFullExpansionTapRecogniser(enabled: false)
         enableDrawerDismissalTapRecogniser(enabled: false)
     }

--- a/DrawerKit/DrawerKit/Internal API/PresentationController.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController.swift
@@ -66,7 +66,7 @@ final class PresentationController: UIPresentationController {
 
         if let scrollView = scrollViewForPullToDismiss, let manager = pullToDismissManager {
             switch targetDrawerState {
-            case .partiallyExpanded, .dismissed:
+            case .partiallyExpanded, .dismissed, .collapsed:
                 scrollView.isScrollEnabled = false
             case .transitioning, .fullyExpanded:
                 scrollView.isScrollEnabled = !manager.scrollViewNeedsTransitionAsDragEnds

--- a/DrawerKit/DrawerKit/Internal API/PresentationController.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController.swift
@@ -55,7 +55,7 @@ final class PresentationController: UIPresentationController {
         self.handleView = (configuration.handleViewConfiguration != nil ? UIView() : nil)
         self.presentingDrawerAnimationActions = presentingDrawerAnimationActions
         self.presentedDrawerAnimationActions = presentedDrawerAnimationActions
-        self.targetDrawerState = configuration.supportsPartialExpansion ? .partiallyExpanded : .fullyExpanded
+        self.targetDrawerState = configuration.initialState ?? (configuration.supportsPartialExpansion ? .partiallyExpanded : .fullyExpanded)
 
         super.init(presentedViewController: presentedVC, presenting: presentingVC)
     }

--- a/DrawerKit/DrawerKit/Public API/Protocols/DrawerPresentable.swift
+++ b/DrawerKit/DrawerKit/Public API/Protocols/DrawerPresentable.swift
@@ -6,4 +6,13 @@ public protocol DrawerPresentable: class {
     /// The height at which the drawer must be presented when it's in its
     /// partially expanded state. If negative, its value is clamped to zero.
     var heightOfPartiallyExpandedDrawer: CGFloat { get }
+
+    /// The height at which the drawer must be presented when it's in its
+    /// collapsed state. If negative, its value is clamped to zero.
+    /// Default implementation returns 0.
+    var heightOfCollapsedDrawer: CGFloat { get }
+}
+
+public extension DrawerPresentable {
+    var heightOfCollapsedDrawer: CGFloat { return 0 }
 }

--- a/DrawerKit/DrawerKit/Public API/Structs/DrawerConfiguration.swift
+++ b/DrawerKit/DrawerKit/Public API/Structs/DrawerConfiguration.swift
@@ -50,14 +50,14 @@ public struct DrawerConfiguration {
     public var initialState: DrawerState?
 
     /// The total duration, in seconds, for the drawer to transition from its
-    /// collapsed state to its fully-expanded state, or vice-versa. The default
+    /// dismissed state to its fully-expanded state, or vice-versa. The default
     /// value is 0.4 seconds.
     public var totalDurationInSeconds: TimeInterval
 
-    /// When the drawer transitions between its collapsed and partially-expanded
+    /// When the drawer transitions between its dismissed and partially-expanded
     /// states, or between its partially-expanded and its fully-expanded states, in
     /// either direction, the distance traveled by the drawer is some fraction of
-    /// the total distance traveled between the collapsed and fully-expanded states.
+    /// the total distance traveled between the dismissed and fully-expanded states.
     /// You have a choice between having those fractional transitions take the same
     /// amount of time as the full transition, and having them take a time that is
     /// a fraction of the total time, where the fraction used is the fraction of
@@ -89,11 +89,11 @@ public struct DrawerConfiguration {
 
     /// When `true`, dismissing the drawer from its fully expanded state can result
     /// in the drawer stopping at its partially expanded state. When `false`, the
-    /// dismissal is always straight to the collapsed state. Note that
+    /// dismissal is always straight to the dismissed state. Note that
     /// `supportsPartialExpansion` being `false` implies `dismissesInStages` being
     /// `false` as well but you can have `supportsPartialExpansion == true` and
     /// `dismissesInStages == false`, which would result in presentations to the
-    /// partially expanded state but all dismissals would be straight to the collapsed
+    /// partially expanded state but all dismissals would be straight to the dismissed
     /// state. The default value is `true`.
     public var dismissesInStages: Bool
 

--- a/DrawerKit/DrawerKit/Public API/Structs/DrawerConfiguration.swift
+++ b/DrawerKit/DrawerKit/Public API/Structs/DrawerConfiguration.swift
@@ -45,6 +45,10 @@ public struct DrawerConfiguration {
         case alwaysShowBelowStatusBar
     }
 
+    /// Intial state of presented drawer. Default is `nil`, If `nil` then
+    /// state will be computed based on `supportsPartialExpansion` flag.
+    public var initialState: DrawerState?
+
     /// The total duration, in seconds, for the drawer to transition from its
     /// collapsed state to its fully-expanded state, or vice-versa. The default
     /// value is 0.4 seconds.
@@ -157,7 +161,8 @@ public struct DrawerConfiguration {
     /// property to `nil` so as not to have a drawer shadow. The default value is `nil`.
     public var drawerShadowConfiguration: DrawerShadowConfiguration?
 
-    public init(totalDurationInSeconds: TimeInterval = 0.4,
+    public init(initialState: DrawerState? = nil,
+                totalDurationInSeconds: TimeInterval = 0.4,
                 durationIsProportionalToDistanceTraveled: Bool = false,
                 timingCurveProvider: UITimingCurveProvider = UISpringTimingParameters(),
                 fullExpansionBehaviour: FullExpansionBehaviour = .coversFullScreen,
@@ -176,6 +181,7 @@ public struct DrawerConfiguration {
                 handleViewConfiguration: HandleViewConfiguration? = HandleViewConfiguration(),
                 drawerBorderConfiguration: DrawerBorderConfiguration? = nil,
                 drawerShadowConfiguration: DrawerShadowConfiguration? = nil) {
+        self.initialState = initialState
         self.totalDurationInSeconds = (totalDurationInSeconds > 0 ? totalDurationInSeconds : 0.4)
         self.durationIsProportionalToDistanceTraveled = durationIsProportionalToDistanceTraveled
         self.timingCurveProvider = timingCurveProvider

--- a/DrawerKit/DrawerKit/Public API/Structs/DrawerState.swift
+++ b/DrawerKit/DrawerKit/Public API/Structs/DrawerState.swift
@@ -3,7 +3,7 @@ import UIKit
 /// An enumeration to describe the various states the drawer can be in.
 
 public enum DrawerState: Equatable { // the implementation of Equatable is internal
-    case collapsed
+    case dismissed
     case partiallyExpanded
     case fullyExpanded
     case transitioning(currentDrawerY: CGFloat)

--- a/DrawerKit/DrawerKit/Public API/Structs/DrawerState.swift
+++ b/DrawerKit/DrawerKit/Public API/Structs/DrawerState.swift
@@ -4,6 +4,7 @@ import UIKit
 
 public enum DrawerState: Equatable { // the implementation of Equatable is internal
     case dismissed
+    case collapsed
     case partiallyExpanded
     case fullyExpanded
     case transitioning(currentDrawerY: CGFloat)

--- a/DrawerKit/DrawerKit/Public API/Structs/HandleViewConfiguration.swift
+++ b/DrawerKit/DrawerKit/Public API/Structs/HandleViewConfiguration.swift
@@ -22,7 +22,7 @@ public struct HandleViewConfiguration {
     }
 
     /// Whether or not to automatically dim the handle view as the drawer approaches
-    /// its collapsed or fully expanded states. The default is `true`. Set it to `false`
+    /// its dismissed or fully expanded states. The default is `true`. Set it to `false`
     /// when configuring the drawer not to cover the full screen so that the handle view
     /// is always visible in that case.
     public var autoAnimatesDimming: Bool

--- a/DrawerKitDemo/DrawerKitDemo/PresentedNavigationController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresentedNavigationController.swift
@@ -17,6 +17,10 @@ extension PresentedNavigationController: DrawerAnimationParticipant {
 }
 
 extension PresentedNavigationController: DrawerPresentable {
+    var heightOfCollapsedDrawer: CGFloat {
+        return (topViewController as? DrawerPresentable)?.heightOfCollapsedDrawer ?? 0.0
+    }
+
     var heightOfPartiallyExpandedDrawer: CGFloat {
         return (topViewController as? DrawerPresentable)?.heightOfPartiallyExpandedDrawer ?? 0.0
     }

--- a/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
@@ -50,13 +50,13 @@ extension PresentedViewController: DrawerAnimationParticipant {
         let prepareAction: DrawerAnimationActions.PrepareHandler = {
             [weak self] info in
             switch (info.startDrawerState, info.endDrawerState) {
-            case (.collapsed, .partiallyExpanded):
+            case (.dismissed, .partiallyExpanded):
                 self?.presentedView.prepareCollapsedToPartiallyExpanded()
-            case (.partiallyExpanded, .collapsed):
+            case (.partiallyExpanded, .dismissed):
                 self?.presentedView.preparePartiallyExpandedToCollapsed()
-            case (.collapsed, .fullyExpanded):
+            case (.dismissed, .fullyExpanded):
                 self?.presentedView.prepareCollapsedToFullyExpanded()
-            case (.fullyExpanded, .collapsed):
+            case (.fullyExpanded, .dismissed):
                 self?.presentedView.prepareFullyExpandedToCollapsed()
             case (.partiallyExpanded, .fullyExpanded):
                 self?.presentedView.preparePartiallyExpandedToFullyExpanded()
@@ -70,13 +70,13 @@ extension PresentedViewController: DrawerAnimationParticipant {
         let animateAlongAction: DrawerAnimationActions.AnimateAlongHandler = {
             [weak self] info in
             switch (info.startDrawerState, info.endDrawerState) {
-            case (.collapsed, .partiallyExpanded):
+            case (.dismissed, .partiallyExpanded):
                 self?.presentedView.animateAlongCollapsedToPartiallyExpanded()
-            case (.partiallyExpanded, .collapsed):
+            case (.partiallyExpanded, .dismissed):
                 self?.presentedView.animateAlongPartiallyExpandedToCollapsed()
-            case (.collapsed, .fullyExpanded):
+            case (.dismissed, .fullyExpanded):
                 self?.presentedView.animateAlongCollapsedToFullyExpanded()
-            case (.fullyExpanded, .collapsed):
+            case (.fullyExpanded, .dismissed):
                 self?.presentedView.animateAlongFullyExpandedToCollapsed()
             case (.partiallyExpanded, .fullyExpanded):
                 self?.presentedView.animateAlongPartiallyExpandedToFullyExpanded()
@@ -90,13 +90,13 @@ extension PresentedViewController: DrawerAnimationParticipant {
         let cleanupAction: DrawerAnimationActions.CleanupHandler = {
             [weak self] info in
             switch (info.startDrawerState, info.endDrawerState) {
-            case (.collapsed, .partiallyExpanded):
+            case (.dismissed, .partiallyExpanded):
                 self?.presentedView.cleanupCollapsedToPartiallyExpanded()
-            case (.partiallyExpanded, .collapsed):
+            case (.partiallyExpanded, .dismissed):
                 self?.presentedView.cleanupPartiallyExpandedToCollapsed()
-            case (.collapsed, .fullyExpanded):
+            case (.dismissed, .fullyExpanded):
                 self?.presentedView.cleanupCollapsedToFullyExpanded()
-            case (.fullyExpanded, .collapsed):
+            case (.fullyExpanded, .dismissed):
                 self?.presentedView.cleanupFullyExpandedToCollapsed()
             case (.partiallyExpanded, .fullyExpanded):
                 self?.presentedView.cleanupPartiallyExpandedToFullyExpanded()

--- a/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
@@ -30,9 +30,9 @@ extension PresentedViewController: UIScrollViewDelegate {}
 
 extension PresentedViewController: DrawerPresentable {
 
-    var heightOfCollapsedDrawer: CGFloat {
-        return 100
-    }
+//    var heightOfCollapsedDrawer: CGFloat {
+//        return 100
+//    }
 
     var heightOfPartiallyExpandedDrawer: CGFloat {
         guard let view = self.view as? PresentedView else { return 0 }

--- a/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
@@ -29,6 +29,11 @@ class PresentedViewController: UIViewController {
 extension PresentedViewController: UIScrollViewDelegate {}
 
 extension PresentedViewController: DrawerPresentable {
+
+    var heightOfCollapsedDrawer: CGFloat {
+        return 100
+    }
+
     var heightOfPartiallyExpandedDrawer: CGFloat {
         guard let view = self.view as? PresentedView else { return 0 }
 

--- a/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
@@ -30,9 +30,9 @@ extension PresentedViewController: UIScrollViewDelegate {}
 
 extension PresentedViewController: DrawerPresentable {
 
-//    var heightOfCollapsedDrawer: CGFloat {
-//        return 100
-//    }
+    var heightOfCollapsedDrawer: CGFloat {
+        return 100
+    }
 
     var heightOfPartiallyExpandedDrawer: CGFloat {
         guard let view = self.view as? PresentedView else { return 0 }

--- a/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
@@ -21,14 +21,14 @@ private extension PresenterViewController {
         // what you need to configure differently. They're all listed here just so you
         // can see what can be configured. The values listed are the default ones,
         // except where indicated otherwise.
-        //configuration.initialState = .collapsed
+        configuration.initialState = .collapsed
         configuration.totalDurationInSeconds = 0.4
         configuration.durationIsProportionalToDistanceTraveled = false
         // default is UISpringTimingParameters()
         configuration.timingCurveProvider = UISpringTimingParameters(dampingRatio: 0.8)
         configuration.fullExpansionBehaviour = .coversFullScreen
         configuration.supportsPartialExpansion = true
-        configuration.dismissesInStages = true
+        configuration.dismissesInStages = false
         configuration.isDrawerDraggable = true
         configuration.isFullyPresentableByDrawerTaps = true
         configuration.numberOfTapsForFullDrawerPresentation = 1

--- a/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
@@ -21,7 +21,7 @@ private extension PresenterViewController {
         // what you need to configure differently. They're all listed here just so you
         // can see what can be configured. The values listed are the default ones,
         // except where indicated otherwise.
-        configuration.initialState = nil
+        configuration.initialState = .collapsed
         configuration.totalDurationInSeconds = 0.4
         configuration.durationIsProportionalToDistanceTraveled = false
         // default is UISpringTimingParameters()

--- a/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
@@ -21,7 +21,7 @@ private extension PresenterViewController {
         // what you need to configure differently. They're all listed here just so you
         // can see what can be configured. The values listed are the default ones,
         // except where indicated otherwise.
-        configuration.initialState = .collapsed
+//        configuration.initialState = .collapsed
         configuration.totalDurationInSeconds = 0.4
         configuration.durationIsProportionalToDistanceTraveled = false
         // default is UISpringTimingParameters()

--- a/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
@@ -21,6 +21,7 @@ private extension PresenterViewController {
         // what you need to configure differently. They're all listed here just so you
         // can see what can be configured. The values listed are the default ones,
         // except where indicated otherwise.
+        configuration.initialState = nil
         configuration.totalDurationInSeconds = 0.4
         configuration.durationIsProportionalToDistanceTraveled = false
         // default is UISpringTimingParameters()

--- a/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
@@ -21,7 +21,7 @@ private extension PresenterViewController {
         // what you need to configure differently. They're all listed here just so you
         // can see what can be configured. The values listed are the default ones,
         // except where indicated otherwise.
-        configuration.initialState = .collapsed
+        //configuration.initialState = .collapsed
         configuration.totalDurationInSeconds = 0.4
         configuration.durationIsProportionalToDistanceTraveled = false
         // default is UISpringTimingParameters()

--- a/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
@@ -28,7 +28,7 @@ private extension PresenterViewController {
         configuration.timingCurveProvider = UISpringTimingParameters(dampingRatio: 0.8)
         configuration.fullExpansionBehaviour = .coversFullScreen
         configuration.supportsPartialExpansion = true
-        configuration.dismissesInStages = false
+        configuration.dismissesInStages = true
         configuration.isDrawerDraggable = true
         configuration.isFullyPresentableByDrawerTaps = true
         configuration.numberOfTapsForFullDrawerPresentation = 1


### PR DESCRIPTION
This PR adds support for configurable initial state and collapsed state height. Currently it's only possible to completely hide drawer in collapsed state which also results in dismissing view controller. With this change it's possible to make drawer visible not just in partial or fully expanded state, but also in collapsed state without introducing any additional state.

![20181024211114](https://user-images.githubusercontent.com/1488293/47458570-cb13a880-d7d1-11e8-996a-7e7c7cf18ce9.gif)

When collapsed state is chosen as initial and it has non-zero height then dismissing on collapsed state becomes unneeded so it is not happening in this case.
~Also added ability to not animate corner radius as with current implementation it will be animated in between collapsed and partially expanded state which also seems to be undesirable when collapsed state has non-zero height. Though it can be made configurable with `minimumCornerRadius` which will correspond to corner radius in collapsed state. But this can be done as a separate PR.~ This is now part of #77 