### PR TITLE
Support interactions on presented view

### DIFF
--- a/DrawerKit/DrawerKit.xcodeproj/project.pbxproj
+++ b/DrawerKit/DrawerKit.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		654604CE207BD4BC00B72395 /* DrawerPresentationControlling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654604CD207BD4BC00B72395 /* DrawerPresentationControlling.swift */; };
 		9A158BC22076C92200FD4113 /* PresentationController+PullToDismiss.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A158BC12076C92200FD4113 /* PresentationController+PullToDismiss.swift */; };
+		B5D4058C21811B77000B3349 /* PresentationContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D4058B21811B77000B3349 /* PresentationContainerView.swift */; };
 		CB1B6DF31FC346CC006C1F89 /* DrawerShadowConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB1B6DF21FC346CC006C1F89 /* DrawerShadowConfiguration.swift */; };
 		CB1B6E011FC8629B006C1F89 /* DrawerBorderConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB1B6E001FC8629B006C1F89 /* DrawerBorderConfiguration.swift */; };
 		CB2CB7941F8E934500AA152D /* DrawerPresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB2CB78D1F8E934500AA152D /* DrawerPresentable.swift */; };
@@ -44,6 +45,7 @@
 /* Begin PBXFileReference section */
 		654604CD207BD4BC00B72395 /* DrawerPresentationControlling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerPresentationControlling.swift; sourceTree = "<group>"; };
 		9A158BC12076C92200FD4113 /* PresentationController+PullToDismiss.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PresentationController+PullToDismiss.swift"; sourceTree = "<group>"; };
+		B5D4058B21811B77000B3349 /* PresentationContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationContainerView.swift; sourceTree = "<group>"; };
 		CB1B6DF21FC346CC006C1F89 /* DrawerShadowConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DrawerShadowConfiguration.swift; sourceTree = "<group>"; };
 		CB1B6E001FC8629B006C1F89 /* DrawerBorderConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DrawerBorderConfiguration.swift; sourceTree = "<group>"; };
 		CB2CB78D1F8E934500AA152D /* DrawerPresentable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DrawerPresentable.swift; sourceTree = "<group>"; };
@@ -118,6 +120,7 @@
 				CB2CB79C1F8E951900AA152D /* AnimationController.swift */,
 				CBFA36F11F9C4004006847BB /* GeometryEvaluator.swift */,
 				CBACF6B21F9C622300C15CA3 /* AnimationSupport.swift */,
+				B5D4058B21811B77000B3349 /* PresentationContainerView.swift */,
 			);
 			path = "Internal API";
 			sourceTree = "<group>";
@@ -268,6 +271,7 @@
 				CB5AF8061F9BE0E3000B2DC9 /* DrawerGeometry.swift in Sources */,
 				CB5AF8021F9BDF29000B2DC9 /* DrawerAnimationActions.swift in Sources */,
 				CB2CB7941F8E934500AA152D /* DrawerPresentable.swift in Sources */,
+				B5D4058C21811B77000B3349 /* PresentationContainerView.swift in Sources */,
 				CB3CAFC01FB24BD800AD28A1 /* Notifications.swift in Sources */,
 				CB5AF8001F9BDAC5000B2DC9 /* DrawerAnimationParticipant.swift in Sources */,
 				CB619CEC1F8FFBAD0076E1DE /* InteractionController.swift in Sources */,

--- a/DrawerKit/DrawerKit/Internal API/PresentationContainerView.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationContainerView.swift
@@ -1,0 +1,34 @@
+import UIKit
+
+public struct PassthroughOptions: OptionSet {
+    public let rawValue: Int
+
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+    public static let collapsed            = PassthroughOptions(rawValue: 1 << 0)
+    public static let partiallyExpanded    = PassthroughOptions(rawValue: 1 << 1)
+    public static let fullyExpanded        = PassthroughOptions(rawValue: 1 << 2)
+    public static let all: PassthroughOptions = [.collapsed, .partiallyExpanded, .fullyExpanded]
+}
+
+protocol PresentationContainerViewDelegate: class {
+    func view(_ view: PresentationContainerView, shouldPassthroughTouchAt point: CGPoint) -> Bool
+    func view(_ view: PresentationContainerView, forTouchAt point: CGPoint) -> UIView?
+}
+
+class PresentationContainerView: UIView {
+    weak var touchDelegate: PresentationContainerViewDelegate?
+
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        guard let touchDelegate = touchDelegate,
+            touchDelegate.view(self, shouldPassthroughTouchAt: point),
+            let viewForTouch = touchDelegate.view(self, forTouchAt: point) else {
+                return super.hitTest(point, with: event)
+        }
+
+        let pointInView = viewForTouch.convert(point, from: self)
+        return viewForTouch.hitTest(pointInView, with: event)
+    }
+}

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Setup.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Setup.swift
@@ -20,7 +20,7 @@ extension PresentationController {
 
     func removePresentationContainerView() {
         // the containerView is removed by UIKit when dismissal ends
-        // so it's not necessary to restore it in it's superview
+        // so it's not necessary to restore it in its original superview
         presentationContainerView.removeFromSuperview()
     }
 }

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Setup.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Setup.swift
@@ -19,6 +19,8 @@ extension PresentationController {
     }
 
     func removePresentationContainerView() {
+        // the containerView is removed by UIKit when dismissal end
+        // so it's not necessary to restore it in it's superview
         presentationContainerView.removeFromSuperview()
     }
 }

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Setup.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Setup.swift
@@ -1,6 +1,29 @@
 import UIKit
 
 extension PresentationController {
+    func setupPresentationContainerView() {
+        guard self.presentationContainerView == nil else { return }
+
+        let presentationContainerView = PresentationContainerView()
+        presentationContainerView.touchDelegate = self
+        presentationContainerView.backgroundColor = .clear
+        presentationContainerView.frame = containerView?.superview?.frame ?? .zero
+        presentationContainerView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+
+        if let containerView = containerView {
+            containerView.superview?.addSubview(presentationContainerView)
+            presentationContainerView.addSubview(containerView)
+        }
+
+        self.presentationContainerView = presentationContainerView
+    }
+
+    func removePresentationContainerView() {
+        presentationContainerView.removeFromSuperview()
+    }
+}
+
+extension PresentationController {
     func setupDrawerFullExpansionTapRecogniser() {
         guard drawerFullExpansionTapGR == nil else { return }
         let isFullyPresentable = isFullyPresentableByDrawerTaps

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Setup.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Setup.swift
@@ -19,7 +19,7 @@ extension PresentationController {
     }
 
     func removePresentationContainerView() {
-        // the containerView is removed by UIKit when dismissal end
+        // the containerView is removed by UIKit when dismissal ends
         // so it's not necessary to restore it in it's superview
         presentationContainerView.removeFromSuperview()
     }

--- a/DrawerKit/DrawerKit/Public API/Structs/DrawerConfiguration.swift
+++ b/DrawerKit/DrawerKit/Public API/Structs/DrawerConfiguration.swift
@@ -157,6 +157,10 @@ public struct DrawerConfiguration {
     /// property to `nil` so as not to have a drawer shadow. The default value is `nil`.
     public var drawerShadowConfiguration: DrawerShadowConfiguration?
 
+    /// In what states touches should be passed through to the presenting view.
+    /// By default touches will not be passed through only in `fullyExpanded` state.
+    public var passthroughTouchesInStates: PassthroughOptions
+
     public init(totalDurationInSeconds: TimeInterval = 0.4,
                 durationIsProportionalToDistanceTraveled: Bool = false,
                 timingCurveProvider: UITimingCurveProvider = UISpringTimingParameters(),
@@ -175,7 +179,8 @@ public struct DrawerConfiguration {
                 cornerAnimationOption: CornerAnimationOption = .maximumAtPartialY,
                 handleViewConfiguration: HandleViewConfiguration? = HandleViewConfiguration(),
                 drawerBorderConfiguration: DrawerBorderConfiguration? = nil,
-                drawerShadowConfiguration: DrawerShadowConfiguration? = nil) {
+                drawerShadowConfiguration: DrawerShadowConfiguration? = nil,
+                passthroughTouchesInStates: PassthroughOptions = [.collapsed, .partiallyExpanded]) {
         self.totalDurationInSeconds = (totalDurationInSeconds > 0 ? totalDurationInSeconds : 0.4)
         self.durationIsProportionalToDistanceTraveled = durationIsProportionalToDistanceTraveled
         self.timingCurveProvider = timingCurveProvider
@@ -202,6 +207,7 @@ public struct DrawerConfiguration {
         self.handleViewConfiguration = handleViewConfiguration
         self.drawerBorderConfiguration = drawerBorderConfiguration
         self.drawerShadowConfiguration = drawerShadowConfiguration
+        self.passthroughTouchesInStates = passthroughTouchesInStates
     }
 }
 

--- a/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
@@ -5,12 +5,22 @@ class PresenterViewController: UIViewController, DrawerCoordinating {
     /* strong */ var drawerDisplayController: DrawerDisplayController?
 
     @IBAction func presentButtonTapped() {
-        doModalPresentation()
+        doModalPresentation(passthrough: false)
+    }
+
+    @IBAction func presentButtonDoubleTapped() {
+        doModalPresentation(passthrough: true)
+    }
+
+    @IBAction func alertButtonTapped() {
+        let alert = UIAlertController(title: "Alert", message: "", preferredStyle: .alert)
+        alert.addAction(UIAlertAction.init(title: "OK", style: .default, handler: nil))
+        self.presentedViewController?.present(alert, animated: true, completion: nil)
     }
 }
 
 private extension PresenterViewController {
-    func doModalPresentation() {
+    func doModalPresentation(passthrough: Bool) {
         guard let vc = storyboard?.instantiateViewController(withIdentifier: "presented")
             as? PresentedNavigationController else { return }
 
@@ -25,7 +35,7 @@ private extension PresenterViewController {
         configuration.durationIsProportionalToDistanceTraveled = false
         // default is UISpringTimingParameters()
         configuration.timingCurveProvider = UISpringTimingParameters(dampingRatio: 0.8)
-        configuration.fullExpansionBehaviour = .coversFullScreen
+        configuration.fullExpansionBehaviour = .leavesCustomGap(gap: 150)
         configuration.supportsPartialExpansion = true
         configuration.dismissesInStages = true
         configuration.isDrawerDraggable = true
@@ -37,6 +47,7 @@ private extension PresenterViewController {
         configuration.upperMarkGap = 100 // default is 40
         configuration.lowerMarkGap =  80 // default is 40
         configuration.maximumCornerRadius = 15
+        configuration.passthroughTouchesInStates = passthrough ? [.collapsed, .partiallyExpanded] : []
 
         var handleViewConfiguration = HandleViewConfiguration()
         handleViewConfiguration.autoAnimatesDimming = true

--- a/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
@@ -15,7 +15,7 @@ class PresenterViewController: UIViewController, DrawerCoordinating {
     @IBAction func alertButtonTapped() {
         let alert = UIAlertController(title: "Alert", message: "", preferredStyle: .alert)
         alert.addAction(UIAlertAction.init(title: "OK", style: .default, handler: nil))
-        self.presentedViewController?.present(alert, animated: true, completion: nil)
+        (self.presentedViewController ?? self).present(alert, animated: true, completion: nil)
     }
 }
 
@@ -36,7 +36,7 @@ private extension PresenterViewController {
         configuration.durationIsProportionalToDistanceTraveled = false
         // default is UISpringTimingParameters()
         configuration.timingCurveProvider = UISpringTimingParameters(dampingRatio: 0.8)
-        configuration.fullExpansionBehaviour = .leavesCustomGap(gap: 150)
+        configuration.fullExpansionBehaviour = .coversFullScreen
         configuration.supportsPartialExpansion = true
         configuration.dismissesInStages = true
         configuration.isDrawerDraggable = true

--- a/DrawerKitDemo/DrawerKitDemo/Storyboards/Base.lproj/Main.storyboard
+++ b/DrawerKitDemo/DrawerKitDemo/Storyboards/Base.lproj/Main.storyboard
@@ -32,7 +32,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zqC-oY-NTg">
-                                <rect key="frame" x="0.0" y="90" width="375" height="487"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
                                 <accessibility key="accessibilityConfiguration" identifier="mainCanvas"/>
                                 <gestureRecognizers/>
                                 <state key="normal">
@@ -41,31 +41,18 @@
                                 <connections>
                                     <action selector="presentButtonTapped" destination="uBw-Sr-LpF" eventType="touchUpInside" id="ROy-A5-vzk"/>
                                     <outletCollection property="gestureRecognizers" destination="biI-9V-ig5" appends="YES" id="vSE-Uj-jCd"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mT6-dc-gM1">
-                                <rect key="frame" x="171" y="60" width="33" height="30"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="30" id="M9V-Oy-TbX"/>
-                                </constraints>
-                                <state key="normal" title="Alert">
-                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                </state>
-                                <connections>
-                                    <action selector="alertButtonTapped" destination="uBw-Sr-LpF" eventType="touchUpInside" id="4Et-YI-7sK"/>
+                                    <outletCollection property="gestureRecognizers" destination="HER-mx-HJG" appends="YES" id="8lM-f4-epj"/>
                                 </connections>
                             </button>
                         </subviews>
                         <color key="backgroundColor" red="0.24548156692070328" green="0.44175364460593769" blue="0.61927218264248707" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                         <constraints>
-                            <constraint firstItem="zqC-oY-NTg" firstAttribute="top" secondItem="mT6-dc-gM1" secondAttribute="bottom" id="7p9-ir-jZ2"/>
-                            <constraint firstItem="mT6-dc-gM1" firstAttribute="centerX" secondItem="kpO-ML-Q54" secondAttribute="centerX" id="BJG-Mf-P1w"/>
                             <constraint firstItem="E1R-4Q-Kln" firstAttribute="centerY" secondItem="kpO-ML-Q54" secondAttribute="centerY" id="Zhb-3P-Akq"/>
                             <constraint firstItem="E1R-4Q-Kln" firstAttribute="centerX" secondItem="kpO-ML-Q54" secondAttribute="centerX" id="chs-2Y-Dg5"/>
-                            <constraint firstItem="zqC-oY-NTg" firstAttribute="centerY" secondItem="kpO-ML-Q54" secondAttribute="centerY" id="g9w-F7-JVk"/>
-                            <constraint firstItem="mT6-dc-gM1" firstAttribute="top" secondItem="eUk-bQ-xyb" secondAttribute="bottom" constant="40" id="jNZ-yF-aZ0"/>
                             <constraint firstAttribute="trailing" secondItem="zqC-oY-NTg" secondAttribute="trailing" id="jxk-gc-Uqa"/>
                             <constraint firstItem="zqC-oY-NTg" firstAttribute="leading" secondItem="kpO-ML-Q54" secondAttribute="leading" id="rnK-kU-a7Q"/>
+                            <constraint firstItem="zqC-oY-NTg" firstAttribute="top" secondItem="eUk-bQ-xyb" secondAttribute="bottom" id="wYF-b9-gqO"/>
+                            <constraint firstItem="ZsS-x3-G2B" firstAttribute="top" secondItem="zqC-oY-NTg" secondAttribute="bottom" id="zoo-za-lxb"/>
                         </constraints>
                     </view>
                 </viewController>
@@ -75,6 +62,11 @@
                         <action selector="presentButtonDoubleTapped" destination="uBw-Sr-LpF" id="kiH-5x-R81"/>
                     </connections>
                 </tapGestureRecognizer>
+                <pongPressGestureRecognizer allowableMovement="10" minimumPressDuration="0.5" id="HER-mx-HJG">
+                    <connections>
+                        <action selector="alertButtonTapped" destination="uBw-Sr-LpF" id="LdR-GM-qDt"/>
+                    </connections>
+                </pongPressGestureRecognizer>
             </objects>
             <point key="canvasLocation" x="-5634.3999999999996" y="-3600.4497751124441"/>
         </scene>

--- a/DrawerKitDemo/DrawerKitDemo/Storyboards/Base.lproj/Main.storyboard
+++ b/DrawerKitDemo/DrawerKitDemo/Storyboards/Base.lproj/Main.storyboard
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="uBw-Sr-LpF">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="uBw-Sr-LpF">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
-        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -24,7 +22,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tap anywhere to display the drawer" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E1R-4Q-Kln">
-                                <rect key="frame" x="102" y="309.5" width="170" height="48"/>
+                                <rect key="frame" x="102.5" y="309.5" width="170" height="48"/>
                                 <accessibility key="accessibilityConfiguration" identifier="canvasDescription"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="170" id="Npx-Nk-42o"/>
@@ -34,30 +32,51 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zqC-oY-NTg">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                                <rect key="frame" x="0.0" y="90" width="375" height="487"/>
                                 <accessibility key="accessibilityConfiguration" identifier="mainCanvas"/>
+                                <gestureRecognizers/>
                                 <state key="normal">
                                     <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                                 <connections>
                                     <action selector="presentButtonTapped" destination="uBw-Sr-LpF" eventType="touchUpInside" id="ROy-A5-vzk"/>
+                                    <outletCollection property="gestureRecognizers" destination="biI-9V-ig5" appends="YES" id="vSE-Uj-jCd"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mT6-dc-gM1">
+                                <rect key="frame" x="171" y="60" width="33" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="30" id="M9V-Oy-TbX"/>
+                                </constraints>
+                                <state key="normal" title="Alert">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
+                                <connections>
+                                    <action selector="alertButtonTapped" destination="uBw-Sr-LpF" eventType="touchUpInside" id="4Et-YI-7sK"/>
                                 </connections>
                             </button>
                         </subviews>
                         <color key="backgroundColor" red="0.24548156692070328" green="0.44175364460593769" blue="0.61927218264248707" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                         <constraints>
-                            <constraint firstItem="zqC-oY-NTg" firstAttribute="top" secondItem="kpO-ML-Q54" secondAttribute="top" id="AEn-Aq-JuT"/>
-                            <constraint firstAttribute="bottom" secondItem="zqC-oY-NTg" secondAttribute="bottom" id="DQh-oV-xMJ"/>
+                            <constraint firstItem="zqC-oY-NTg" firstAttribute="top" secondItem="mT6-dc-gM1" secondAttribute="bottom" id="7p9-ir-jZ2"/>
+                            <constraint firstItem="mT6-dc-gM1" firstAttribute="centerX" secondItem="kpO-ML-Q54" secondAttribute="centerX" id="BJG-Mf-P1w"/>
                             <constraint firstItem="E1R-4Q-Kln" firstAttribute="centerY" secondItem="kpO-ML-Q54" secondAttribute="centerY" id="Zhb-3P-Akq"/>
                             <constraint firstItem="E1R-4Q-Kln" firstAttribute="centerX" secondItem="kpO-ML-Q54" secondAttribute="centerX" id="chs-2Y-Dg5"/>
+                            <constraint firstItem="zqC-oY-NTg" firstAttribute="centerY" secondItem="kpO-ML-Q54" secondAttribute="centerY" id="g9w-F7-JVk"/>
+                            <constraint firstItem="mT6-dc-gM1" firstAttribute="top" secondItem="eUk-bQ-xyb" secondAttribute="bottom" constant="40" id="jNZ-yF-aZ0"/>
                             <constraint firstAttribute="trailing" secondItem="zqC-oY-NTg" secondAttribute="trailing" id="jxk-gc-Uqa"/>
                             <constraint firstItem="zqC-oY-NTg" firstAttribute="leading" secondItem="kpO-ML-Q54" secondAttribute="leading" id="rnK-kU-a7Q"/>
                         </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Qrz-QE-csW" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <tapGestureRecognizer numberOfTapsRequired="2" id="biI-9V-ig5">
+                    <connections>
+                        <action selector="presentButtonDoubleTapped" destination="uBw-Sr-LpF" id="kiH-5x-R81"/>
+                    </connections>
+                </tapGestureRecognizer>
             </objects>
-            <point key="canvasLocation" x="-5633" y="-3600"/>
+            <point key="canvasLocation" x="-5634.3999999999996" y="-3600.4497751124441"/>
         </scene>
         <!--Presented Navigation Controller-->
         <scene sceneID="EHc-yS-Lt4">
@@ -96,14 +115,14 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="e9r-kz-Vw9">
-                                <rect key="frame" x="38" y="126.5" width="300" height="1"/>
+                                <rect key="frame" x="37.5" y="126.5" width="300" height="1"/>
                                 <color key="backgroundColor" red="1" green="0.039765733839999998" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="pqF-UO-bTE"/>
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7Lf-1M-NuW">
-                                <rect key="frame" x="165" y="66.5" width="44" height="44"/>
+                                <rect key="frame" x="165.5" y="66.5" width="44" height="44"/>
                                 <accessibility key="accessibilityConfiguration" identifier="drawerClose"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="44" id="dmi-Qw-ahk"/>
@@ -120,7 +139,7 @@
                                 </connections>
                             </button>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="750" image="Saturn" translatesAutoresizingMaskIntoConstraints="NO" id="xSt-L4-9Fg">
-                                <rect key="frame" x="38" y="157" width="300" height="1000"/>
+                                <rect key="frame" x="37.5" y="157.5" width="300" height="1000"/>
                                 <accessibility key="accessibilityConfiguration" identifier="saturnImage"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1000" id="wQl-br-6Sy"/>

--- a/DrawerKitDemo/DrawerKitDemoUITests/DrawerKitDemoUITests.swift
+++ b/DrawerKitDemo/DrawerKitDemoUITests/DrawerKitDemoUITests.swift
@@ -3,7 +3,7 @@ import XCTest
 class DrawerKitDemoUITests: XCTestCase {
     
     var app: XCUIApplication!
-    let transitionTimeout: TimeInterval = 1.0
+    let transitionTimeout: TimeInterval = 2.0
     
     enum ElementState: String {
         case exists = "exists == true"
@@ -83,29 +83,17 @@ class DrawerKitDemoUITests: XCTestCase {
     func testTouchesPassthrough() {
         let mainCanvas = app.buttons[Identifiers.mainCanvas]
         mainCanvas.doubleTap()
+        XCTAssertTrue(isDrawerOpen())
 
-        let alertButton = app.buttons["Alert"]
         let alert = app.alerts["Alert"]
 
-        XCTAssertTrue(alertButton.isHittable)
-        alertButton.tap()
+        if #available(iOS 12, *) {
+            mainCanvas.press(forDuration: 1)
+        } else {
+            app.press(forDuration: 1)
+        }
 
-        XCTAssertTrue(alert.exists)
-        alert.buttons.firstMatch.tap()
-
-        let drawer = app.staticTexts[Identifiers.drawerDescription].firstMatch
-        let start = drawer.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
-        let end = mainCanvas.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.1))
-        start.press(forDuration: 0.05, thenDragTo: end)
-
-        XCTAssertFalse(alertButton.isHittable)
-
-        end.press(forDuration: 0.05, thenDragTo: start)
-
-        XCTAssertTrue(alertButton.isHittable)
-        alertButton.tap()
-
-        XCTAssertTrue(alert.exists)
+        XCTAssertTrue(tryWaitFor(element: alert, withState: .exists))
         alert.buttons.firstMatch.tap()
     }
     

--- a/DrawerKitDemo/DrawerKitDemoUITests/DrawerKitDemoUITests.swift
+++ b/DrawerKitDemo/DrawerKitDemoUITests/DrawerKitDemoUITests.swift
@@ -79,6 +79,35 @@ class DrawerKitDemoUITests: XCTestCase {
         XCTAssertFalse(isDrawerOpen())
         XCTAssertFalse(isDrawerFullyOpen())
     }
+
+    func testTouchesPassthrough() {
+        let mainCanvase = app.buttons[Identifiers.mainCanvas]
+        mainCanvase.doubleTap()
+
+        let alertButton = app.buttons["Alert"]
+        let alert = app.alerts["Alert"]
+
+        XCTAssertTrue(alertButton.isHittable)
+        alertButton.tap()
+
+        XCTAssertTrue(alert.exists)
+        alert.buttons.firstMatch.tap()
+
+        let drawer = app.staticTexts[Identifiers.drawerDescription].firstMatch
+        let start = drawer.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+        let end = mainCanvase.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.1))
+        start.press(forDuration: 0.05, thenDragTo: end)
+
+        XCTAssertFalse(alertButton.isHittable)
+
+        end.press(forDuration: 0.05, thenDragTo: start)
+
+        XCTAssertTrue(alertButton.isHittable)
+        alertButton.tap()
+
+        XCTAssertTrue(alert.exists)
+        alert.buttons.firstMatch.tap()
+    }
     
     private func isDrawerOpen() -> Bool {
         let drawer = app.staticTexts[Identifiers.drawerDescription]

--- a/DrawerKitDemo/DrawerKitDemoUITests/DrawerKitDemoUITests.swift
+++ b/DrawerKitDemo/DrawerKitDemoUITests/DrawerKitDemoUITests.swift
@@ -31,9 +31,9 @@ class DrawerKitDemoUITests: XCTestCase {
     }
     
     func testClickAnywhereToClose() {
-        let mainCanvase = app.buttons[Identifiers.mainCanvas]
+        let mainCanvas = app.buttons[Identifiers.mainCanvas]
         XCTAssertFalse(isDrawerOpen())
-        mainCanvase.tap()
+        mainCanvas.tap()
         XCTAssertTrue(isDrawerOpen())
         XCTAssertFalse(isDrawerFullyOpen())
         
@@ -42,9 +42,9 @@ class DrawerKitDemoUITests: XCTestCase {
     }
     
     func testClickButtonToClose() {
-        let mainCanvase = app.buttons[Identifiers.mainCanvas]
+        let mainCanvas = app.buttons[Identifiers.mainCanvas]
         XCTAssertFalse(isDrawerOpen())
-        mainCanvase.tap()
+        mainCanvas.tap()
         XCTAssertTrue(isDrawerOpen())
         XCTAssertFalse(isDrawerFullyOpen())
         
@@ -54,12 +54,12 @@ class DrawerKitDemoUITests: XCTestCase {
     }
     
     func testOpenDrawerAndClose() {
-        let mainCanvase = app.buttons[Identifiers.mainCanvas]
-        mainCanvase.tap()
+        let mainCanvas = app.buttons[Identifiers.mainCanvas]
+        mainCanvas.tap()
         
         let drawer = app.staticTexts[Identifiers.drawerDescription].firstMatch
         let start = drawer.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
-        let end = mainCanvase.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.1))
+        let end = mainCanvas.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.1))
         start.press(forDuration: 0.05, thenDragTo: end)
         XCTAssertTrue(isDrawerFullyOpen())
 
@@ -68,8 +68,8 @@ class DrawerKitDemoUITests: XCTestCase {
     }
     
     func testCloseFullyOpenDrawer() {
-        let mainCanvase = app.buttons[Identifiers.mainCanvas]
-        mainCanvase.tap()
+        let mainCanvas = app.buttons[Identifiers.mainCanvas]
+        mainCanvas.tap()
         
         let drawer = app.staticTexts[Identifiers.drawerDescription]
         drawer.swipeUp()
@@ -81,8 +81,8 @@ class DrawerKitDemoUITests: XCTestCase {
     }
 
     func testTouchesPassthrough() {
-        let mainCanvase = app.buttons[Identifiers.mainCanvas]
-        mainCanvase.doubleTap()
+        let mainCanvas = app.buttons[Identifiers.mainCanvas]
+        mainCanvas.doubleTap()
 
         let alertButton = app.buttons["Alert"]
         let alert = app.alerts["Alert"]
@@ -95,7 +95,7 @@ class DrawerKitDemoUITests: XCTestCase {
 
         let drawer = app.staticTexts[Identifiers.drawerDescription].firstMatch
         let start = drawer.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
-        let end = mainCanvase.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.1))
+        let end = mainCanvas.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.1))
         start.press(forDuration: 0.05, thenDragTo: end)
 
         XCTAssertFalse(alertButton.isHittable)


### PR DESCRIPTION
Currently the presented view is not responding to touches when drawer view is presented because it appears behind `UITransitionView` added by UIKit, which intercepts all the touches.
One option to allow interactions of presented view could be to add its view as subview of `transitionContext.containerView` but that will make it to collide with tap recogniser and can result to unexpected behaviour when dismissing drawer with tap (if drawer is attempted to be presented twice then after it is dismissed UIKit does not call presentation controller methods)
Instead we put container view inside a subclass of `UIView` that implements `hitTest` and delegates it to presentation controller to decide what view, presented or container view should receive touches.
The gif shows that the view on background is accessible in partial expanded state but not in full screen, which can be configured.

![20181024233738](https://user-images.githubusercontent.com/1488293/47467774-df669e00-d7ef-11e8-9679-7e49d9389ddd.gif)