### PR TITLE
Fixed computing state when collapsed height is more than 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # DrawerKit
 
+## Master
+
+- Fixed calculation of current state when `heightOfCollapsedDrawer` is greater than 0.
+
 ## v. 0.7.0
 
 - DrawerKit now supports interactions with the presenting view. By default, the presenting view will receive touch events when the drawer is in the `collapsed` or `partiallyExpanded` state. This can be configured via the new `passthroughTouchesInStates` configuration.

--- a/DrawerKit/DrawerKit/Internal API/AnimationController.swift
+++ b/DrawerKit/DrawerKit/Internal API/AnimationController.swift
@@ -51,12 +51,18 @@ extension AnimationController: UIViewControllerAnimatedTransitioning {
         let partialH = GeometryEvaluator.drawerPartialH(drawerPartialHeight: drawerPartialH,
                                                         containerViewHeight: containerViewH)
 
+        let drawerCollapsedH = (presentedVC as? DrawerPresentable)?.heightOfCollapsedDrawer ?? 0
+        let collapsedH = GeometryEvaluator.drawerPartialH(drawerPartialHeight: drawerCollapsedH,
+                                                          containerViewHeight: containerViewH)
+
         let startDrawerState = GeometryEvaluator.drawerState(for: initialFrame.origin.y,
+                                                             drawerCollapsedHeight: collapsedH,
                                                              drawerPartialHeight: partialH,
                                                              containerViewHeight: containerViewH,
                                                              configuration: configuration)
 
         let targetDrawerState = GeometryEvaluator.drawerState(for: finalFrame.origin.y,
+                                                              drawerCollapsedHeight: collapsedH,
                                                               drawerPartialHeight: partialH,
                                                               containerViewHeight: containerViewH,
                                                               configuration: configuration)

--- a/DrawerKit/DrawerKit/Internal API/GeometryEvaluator.swift
+++ b/DrawerKit/DrawerKit/Internal API/GeometryEvaluator.swift
@@ -73,6 +73,7 @@ struct GeometryEvaluator {
 
 extension GeometryEvaluator {
     static func drawerState(for positionY: CGFloat,
+                            drawerCollapsedHeight: CGFloat,
                             drawerPartialHeight: CGFloat,
                             containerViewHeight: CGFloat,
                             configuration: DrawerConfiguration,
@@ -85,12 +86,17 @@ extension GeometryEvaluator {
                                       containerViewHeight: containerViewHeight)
         if equal(positionY, partialY) { return .partiallyExpanded }
 
+        let collapsedY = drawerCollapsedY(drawerCollapsedHeight: drawerCollapsedHeight,
+                                          containerViewHeight: containerViewHeight)
+        if equal(positionY, collapsedY) { return .collapsed }
+
         if clampToNearest {
             let posY = clamped(positionY,
                                drawerPartialHeight: drawerPartialHeight,
                                containerViewHeight: containerViewHeight,
                                configuration: configuration)
             return drawerState(for: posY,
+                               drawerCollapsedHeight: drawerCollapsedHeight,
                                drawerPartialHeight: drawerPartialHeight,
                                containerViewHeight: containerViewHeight,
                                configuration: configuration)

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Animation.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Animation.swift
@@ -92,6 +92,7 @@ extension PresentationController {
 
             if endingPosition != .end {
                 self.targetDrawerState = GeometryEvaluator.drawerState(for: self.currentDrawerY,
+                                                                       drawerCollapsedHeight: self.drawerCollapsedHeight,
                                                                        drawerPartialHeight: self.drawerPartialY,
                                                                        containerViewHeight: self.containerViewHeight,
                                                                        configuration: self.configuration)

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Properties.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Properties.swift
@@ -52,6 +52,7 @@ extension PresentationController {
     var currentDrawerState: DrawerState {
         get {
             return GeometryEvaluator.drawerState(for: currentDrawerY,
+                                                 drawerCollapsedHeight: drawerCollapsedHeight,
                                                  drawerPartialHeight: drawerPartialHeight,
                                                  containerViewHeight: containerViewHeight,
                                                  configuration: configuration)


### PR DESCRIPTION
When `heightOfCollapsedDrawer > 0` the current state is calculated as `transitioning` instead of `collapsed`.