### PR TITLE
State change method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 - Fixed calculation of current state when `heightOfCollapsedDrawer` is greater than 0.
 - Fixed settings drawer shadow and corner radius at the same time.
-- Fixed `Equality` implementation of `DrawerState`
-- Allow expanding by tap from `collapsed` state
+- Fixed `Equality` implementation of `DrawerState`.
+- Allow expanding by tap from `collapsed` state.
+- Added method in `DrawerPresentationControlling` to change drawer state programmatically.
+- `drawerPresentationController` will return correct value when presented view controller is embedded into `UINavigationController`. 
 
 ## v. 0.7.0
 

--- a/DrawerKit/DrawerKit/Internal API/PresentationController.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController.swift
@@ -155,4 +155,15 @@ extension PresentationController {
     }
 }
 
-extension PresentationController: DrawerPresentationControlling {}
+extension PresentationController: DrawerPresentationControlling {
+    public func setDrawerState(_ state: DrawerState, animated: Bool, completion: (() -> Void)?) {
+        switch state {
+        case .transitioning:
+            fatalError("`transitioning` state is not allowed")
+        case .dismissed:
+            presentedViewController.dismiss(animated: animated, completion: completion)
+        default:
+            animateTransition(to: state, animateAlongside: nil, completion: completion)
+        }
+    }
+}

--- a/DrawerKit/DrawerKit/Internal API/PresentationController.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController.swift
@@ -156,14 +156,16 @@ extension PresentationController {
 }
 
 extension PresentationController: DrawerPresentationControlling {
-    public func setDrawerState(_ state: DrawerState, animated: Bool, completion: (() -> Void)?) {
+    public func setDrawerState(_ state: DrawerState, animated: Bool, animateAlongside: (() -> Void)?, completion: (() -> Void)?) {
         switch state {
         case .transitioning:
             fatalError("`transitioning` state is not allowed")
         case .dismissed:
-            presentedViewController.dismiss(animated: animated, completion: completion)
+            animateTransition(to: .dismissed, animateAlongside: animateAlongside) {
+                self.presentedViewController.dismiss(animated: false, completion: completion)
+            }
         default:
-            animateTransition(to: state, animateAlongside: nil, completion: completion)
+            animateTransition(to: state, animateAlongside: animateAlongside, completion: completion)
         }
     }
 }

--- a/DrawerKit/DrawerKit/Public API/Protocols/DrawerPresentationControlling.swift
+++ b/DrawerKit/DrawerKit/Public API/Protocols/DrawerPresentationControlling.swift
@@ -13,6 +13,22 @@ public protocol DrawerPresentationControlling: class {
     ///
     /// - note: The drawer presentation controller does not retain the view.
     var scrollViewForPullToDismiss: UIScrollView? { get set }
+
+    /// Changes the state of the drawer.
+    /// - parameters:
+    ///   - state: the new drawer state. Passing `.dismissed` value will dismiss the presented view controller.
+    ///            It's not allowed to pass `.transitioning` state, passing it will result in `fatalError`.
+    ///
+    ///   - animated: whether the state change should be animated, default is `true`.
+    ///
+    ///   - completion: a closure to be called when the state transition finishes, default is `nil`.
+    func setDrawerState(_ state: DrawerState, animated: Bool, completion: (() -> Void)?)
+}
+
+extension DrawerPresentationControlling {
+    public func setDrawerState(_ state: DrawerState, animated: Bool = true) {
+        setDrawerState(state, animated: animated, completion: nil)
+    }
 }
 
 extension UIViewController {

--- a/DrawerKit/DrawerKit/Public API/Protocols/DrawerPresentationControlling.swift
+++ b/DrawerKit/DrawerKit/Public API/Protocols/DrawerPresentationControlling.swift
@@ -19,15 +19,17 @@ public protocol DrawerPresentationControlling: class {
     ///   - state: the new drawer state. Passing `.dismissed` value will dismiss the presented view controller.
     ///            It's not allowed to pass `.transitioning` state, passing it will result in `fatalError`.
     ///
+    ///   - animateAlongside: closure to perform alongside transition, default is `nil`.
+    ///
     ///   - animated: whether the state change should be animated, default is `true`.
     ///
     ///   - completion: a closure to be called when the state transition finishes, default is `nil`.
-    func setDrawerState(_ state: DrawerState, animated: Bool, completion: (() -> Void)?)
+    func setDrawerState(_ state: DrawerState, animated: Bool, animateAlongside: (() -> Void)?, completion: (() -> Void)?)
 }
 
 extension DrawerPresentationControlling {
-    public func setDrawerState(_ state: DrawerState, animated: Bool = true) {
-        setDrawerState(state, animated: animated, completion: nil)
+    public func setDrawerState(_ state: DrawerState, animateAlongside: (() -> Void)? = nil, animated: Bool = true) {
+        setDrawerState(state, animated: animated, animateAlongside: animateAlongside, completion: nil)
     }
 }
 

--- a/DrawerKit/DrawerKit/Public API/Protocols/DrawerPresentationControlling.swift
+++ b/DrawerKit/DrawerKit/Public API/Protocols/DrawerPresentationControlling.swift
@@ -33,6 +33,9 @@ extension DrawerPresentationControlling {
 
 extension UIViewController {
     public var drawerPresentationController: DrawerPresentationControlling? {
-        return presentationController as? DrawerPresentationControlling
+        guard let controller = presentationController as? DrawerPresentationControlling else {
+            return navigationController?.drawerPresentationController
+        }
+        return controller
     }
 }

--- a/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
@@ -6,7 +6,7 @@ class PresentedViewController: UIViewController {
 
     @IBOutlet weak var presentedView: PresentedView!
     @IBAction func dismissButtonTapped() {
-        drawerPresentationController?.setDrawerState(.partiallyExpanded)
+        dismiss(animated: true)
     }
 
     override func viewDidLoad() {

--- a/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
@@ -6,7 +6,7 @@ class PresentedViewController: UIViewController {
 
     @IBOutlet weak var presentedView: PresentedView!
     @IBAction func dismissButtonTapped() {
-        dismiss(animated: true)
+        drawerPresentationController?.setDrawerState(.dismissed)
     }
 
     override func viewDidLoad() {

--- a/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
@@ -6,7 +6,7 @@ class PresentedViewController: UIViewController {
 
     @IBOutlet weak var presentedView: PresentedView!
     @IBAction func dismissButtonTapped() {
-        dismiss(animated: true)
+        drawerPresentationController?.setDrawerState(.partiallyExpanded)
     }
 
     override func viewDidLoad() {


### PR DESCRIPTION
In some cases it might be needed to change state of the drawer programmatically. Currently it is only possible with built in gesture recognisers which may handle some of the use cases, but not all. Example is the interaction in iOS maps app when tapping in search bar expands the drawer and tapping "Cancel" button collapses it.