### PR TITLE
Fixed not calling completion block when transitioning drawer to dismissed state

### DIFF
--- a/DrawerKit/DrawerKit/Internal API/PresentationController.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController.swift
@@ -160,10 +160,6 @@ extension PresentationController: DrawerPresentationControlling {
         switch state {
         case .transitioning:
             fatalError("`transitioning` state is not allowed")
-        case .dismissed:
-            animateTransition(to: .dismissed, animateAlongside: animateAlongside) {
-                self.presentedViewController.dismiss(animated: false, completion: completion)
-            }
         default:
             animateTransition(to: state, animateAlongside: animateAlongside, completion: completion)
         }


### PR DESCRIPTION
Dismissing happens already during animation transition so when it is called in the closure it has no effect and completion block is not called