### PR TITLE
Fix memory leak

### DIFF
--- a/DrawerKit/DrawerKit/Internal API/DrawerDisplayController+Extensions.swift
+++ b/DrawerKit/DrawerKit/Internal API/DrawerDisplayController+Extensions.swift
@@ -32,7 +32,11 @@ extension DrawerDisplayController: UIViewControllerTransitioningDelegate {
 
     public func interactionControllerForPresentation(using animator: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
         if #available(iOS 11.0, *) {
-            guard isDrawerDraggable, let presentingVC = presentingVC else { return nil }
+            guard
+                isDrawerDraggable,
+                let presentingVC = presentingVC,
+                let presentedVC = presentedVC
+            else { return nil }
             return InteractionController(isPresentation: true,
                                          presentingVC: presentingVC,
                                          presentedVC: presentedVC)
@@ -48,7 +52,11 @@ extension DrawerDisplayController: UIViewControllerTransitioningDelegate {
 
     public func interactionControllerForDismissal(using animator: UIViewControllerAnimatedTransitioning) -> UIViewControllerInteractiveTransitioning? {
         if #available(iOS 11.0, *) {
-            guard isDrawerDraggable, let presentingVC = presentingVC else { return nil }
+            guard
+                isDrawerDraggable,
+                let presentingVC = presentingVC,
+                let presentedVC = presentedVC
+            else { return nil }
             return InteractionController(isPresentation: false,
                                          presentingVC: presentingVC,
                                          presentedVC: presentedVC)

--- a/DrawerKit/DrawerKit/Public API/DrawerDisplayController.swift
+++ b/DrawerKit/DrawerKit/Public API/DrawerDisplayController.swift
@@ -12,8 +12,8 @@ public final class DrawerDisplayController: NSObject {
     /// The collection of configurable parameters dictating how the drawer works.
     public let configuration: DrawerConfiguration
 
-    weak var presentingVC: UIViewController?
-    weak var presentedVC: (UIViewController & DrawerPresentable)!
+    weak private(set) var presentingVC: UIViewController?
+    weak private(set) var presentedVC: (UIViewController & DrawerPresentable)?
 
     let presentingDrawerAnimationActions: DrawerAnimationActions
     let presentedDrawerAnimationActions: DrawerAnimationActions

--- a/DrawerKit/DrawerKit/Public API/DrawerDisplayController.swift
+++ b/DrawerKit/DrawerKit/Public API/DrawerDisplayController.swift
@@ -13,7 +13,7 @@ public final class DrawerDisplayController: NSObject {
     public let configuration: DrawerConfiguration
 
     weak var presentingVC: UIViewController?
-    /* strong */ var presentedVC: (UIViewController & DrawerPresentable)
+    weak var presentedVC: (UIViewController & DrawerPresentable)!
 
     let presentingDrawerAnimationActions: DrawerAnimationActions
     let presentedDrawerAnimationActions: DrawerAnimationActions


### PR DESCRIPTION
We don't need a strong reference to `presentedVC`.