### PR TITLE
Enable gesture

### DIFF
--- a/DrawerKit/DrawerKit/Internal API/PresentationController.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController.swift
@@ -63,7 +63,10 @@ final class PresentationController: UIPresentationController {
     }
 
     func gestureAvailabilityConditionsDidChange() {
-        drawerDismissalTapGR?.isEnabled = targetDrawerState == .partiallyExpanded
+        drawerDismissalTapGR?.isEnabled =
+            targetDrawerState == .partiallyExpanded ||
+            targetDrawerState == .fullyExpanded ||
+            targetDrawerState == .collapsed
         drawerFullExpansionTapGR?.isEnabled = (targetDrawerState == .partiallyExpanded || targetDrawerState == .collapsed)
 
         if let scrollView = scrollViewForPullToDismiss, let manager = pullToDismissManager {


### PR DESCRIPTION
Fixes #88.

The gesture shouldn't be disabled. This is an implicit undocumented behaviour.
`DrawerKit` already has `DrawerConfiguration.isDismissableByOutsideDrawerTaps`
for disabling the the gesture explicitly.