### PR TITLE
Stop specifying version requirements in the docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ If you use [Carthage][] to manage your dependencies, simply add
 DrawerKit to your `Cartfile`:
 
 ```
-github "Babylonpartners/DrawerKit" ~> 1.0
+github "Babylonpartners/DrawerKit"
 ```
 
 If you use Carthage to build your dependencies, make sure you have added `DrawerKit.framework`
@@ -408,7 +408,7 @@ your Carthage framework copying build phase.
 If you use [CocoaPods][] to manage your dependencies, simply add DrawerKit to your `Podfile`:
 
 ```
-pod 'DrawerKit', '~> 1.0'
+pod 'DrawerKit'
 ```
 
 [CocoaPods]: https://cocoapods.org/


### PR DESCRIPTION
Resolves #92.

Regardless of whether we would eventually bump our prod-deployed release to 1.0, we would be better off not specifying version requirements in the docs for integrating via Carthage and CocoaPods. It should be up to the user to decide whether or not to lock the version after all.