### PR TITLE
Refactor notification types

### DIFF
--- a/DrawerKit/DrawerKit/Internal API/AnimationSupport.swift
+++ b/DrawerKit/DrawerKit/Internal API/AnimationSupport.swift
@@ -52,7 +52,7 @@ struct AnimationSupport {
     static func clientPrepareViews(presentingDrawerAnimationActions: DrawerAnimationActions,
                                    presentedDrawerAnimationActions: DrawerAnimationActions,
                                    _ info: DrawerAnimationInfo) {
-        NotificationCenter.default.post(notification: DrawerNotification.transitionWillStart(info: info))
+        NotificationCenter.default.post(DrawerNotifications.TransitionWillStart(info: info))
         presentingDrawerAnimationActions.prepare?(info)
         presentedDrawerAnimationActions.prepare?(info)
     }
@@ -72,6 +72,6 @@ struct AnimationSupport {
         endInfo.endPosition = endingPosition
         presentingDrawerAnimationActions.cleanup?(info)
         presentedDrawerAnimationActions.cleanup?(info)
-        NotificationCenter.default.post(notification: DrawerNotification.transitionDidFinish(info: info))
+        NotificationCenter.default.post(DrawerNotifications.TransitionDidFinish(info: info))
     }
 }

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Gestures.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Gestures.swift
@@ -5,7 +5,7 @@ extension PresentationController {
         guard let tapGesture = drawerFullExpansionTapGR else { return }
         let tapY = tapGesture.location(in: presentedView).y
         guard tapY < drawerPartialHeight else { return }
-        NotificationCenter.default.post(notification: DrawerNotification.drawerInteriorTapped)
+        NotificationCenter.default.post(DrawerNotifications.DrawerInteriorTapped())
         animateTransition(to: .fullyExpanded)
     }
 
@@ -13,7 +13,7 @@ extension PresentationController {
         guard let tapGesture = drawerDismissalTapGR else { return }
         let tapY = tapGesture.location(in: containerView).y
         guard tapY < currentDrawerY else { return }
-        NotificationCenter.default.post(notification: DrawerNotification.drawerExteriorTapped)
+        NotificationCenter.default.post(DrawerNotifications.DrawerExteriorTapped())
         tapGesture.isEnabled = false
         animateTransition(to: .dismissed)
     }

--- a/DrawerKit/DrawerKit/Public API/DrawerNotifications.swift
+++ b/DrawerKit/DrawerKit/Public API/DrawerNotifications.swift
@@ -1,5 +1,46 @@
 import UIKit
 
+/// Namespace for available `DrawerNotificationInfo`s (a pair of `Notification.Name` and `userInfo`).
+public enum DrawerNotifications {
+    public struct TransitionWillStart: DrawerNotificationInfo {
+        public let info: DrawerAnimationInfo
+        public static let name = Notification.Name(rawValue: "DrawerNotification.transitionWillStart")
+    }
+
+    public struct TransitionDidFinish: DrawerNotificationInfo {
+        public let info: DrawerAnimationInfo
+        public static let name = Notification.Name(rawValue: "DrawerNotification.transitionDidFinish")
+    }
+
+    public struct DrawerInteriorTapped: DrawerNotificationInfo {
+        public static let name = Notification.Name(rawValue: "DrawerNotification.drawerInteriorTapped")
+    }
+
+    public struct DrawerExteriorTapped: DrawerNotificationInfo {
+        public static let name = Notification.Name(rawValue: "DrawerNotification.drawerExteriorTapped")
+    }
+}
+
+// MARK: - DrawerNotificationInfo
+
+/// A pair of `Notification.Name` and type-safe `userInfo`.
+public protocol DrawerNotificationInfo {
+    associatedtype Info = Void
+
+    /// Type-safe `userInfo` alternative.
+    var info: Info { get }
+
+    /// Name of a notification that 1:1 corresponds with `Self`.
+    static var name: Notification.Name { get }
+}
+
+extension DrawerNotificationInfo where Info == Void {
+    public var info: Void { return () }
+}
+
+// MARK: - Deprecated
+
+@available(*, deprecated, message: "Use `DrawerNotifications` instead")
 public enum DrawerNotification: NotificationEnum {
     case transitionWillStart(info: DrawerAnimationInfo)
     case transitionDidFinish(info: DrawerAnimationInfo)
@@ -19,8 +60,15 @@ public enum DrawerNotification: NotificationEnum {
         }
     }
 
+    @available(*, deprecated, renamed: "DrawerNotifications.TransitionWillStart.name")
     public static let transitionWillStartNotification = Notification.Name(rawValue: "DrawerNotification.transitionWillStart")
+
+    @available(*, deprecated, renamed: "DrawerNotifications.TransitionDidFinish.name")
     public static let transitionDidFinishNotification = Notification.Name(rawValue: "DrawerNotification.transitionDidFinish")
+
+    @available(*, deprecated, renamed: "DrawerNotifications.DrawerInteriorTapped.name")
     public static let drawerInteriorTappedNotification = Notification.Name(rawValue: "DrawerNotification.drawerInteriorTapped")
+
+    @available(*, deprecated, renamed: "DrawerNotifications.DrawerExteriorTapped.name")
     public static let drawerExteriorTappedNotification = Notification.Name(rawValue: "DrawerNotification.drawerExteriorTapped")
 }

--- a/DrawerKit/DrawerKit/Public API/Notifications.swift
+++ b/DrawerKit/DrawerKit/Public API/Notifications.swift
@@ -12,6 +12,7 @@ public class NotificationToken {
     deinit { center.removeObserver(token) }
 }
 
+@available(*, deprecated, message: "Do not use this.")
 public protocol NotificationEnum {
     var name: Notification.Name { get }
 }
@@ -19,6 +20,30 @@ public protocol NotificationEnum {
 extension NotificationCenter {
     private static let notificationKey = "notificationKey"
 
+    public func addObserver<T: DrawerNotificationInfo>(_ type: T.Type,
+                                                       object: Any? = nil,
+                                                       queue: OperationQueue? = nil,
+                                                       using block: @escaping (T) -> ()) -> NotificationToken {
+        let token = addObserver(forName: T.name, object: object, queue: queue, using: { note in
+            guard let note = note.userInfo?[NotificationCenter.notificationKey] as? T else {
+                fatalError("incorrect notification key type")
+            }
+            block(note)
+        })
+
+        return NotificationToken(token: token, center: self)
+    }
+
+    internal func post<T: DrawerNotificationInfo>(_ info: T, object: Any? = nil) {
+        let userInfo = [NotificationCenter.notificationKey: info]
+        post(name: T.name, object: object, userInfo: userInfo)
+    }
+}
+
+// MARK: - Deprecated
+
+extension NotificationCenter {
+    @available(*, deprecated, message: "Do not use this.")
     public func addObserver<A: NotificationEnum>(name: Notification.Name,
                                                  object: Any? = nil, queue: OperationQueue? = nil,
                                                  using block: @escaping (A, Any?) -> ()) -> NotificationToken {
@@ -30,6 +55,7 @@ extension NotificationCenter {
         return NotificationToken(token: token, center: self)
     }
 
+    @available(*, deprecated, message: "Do not use this.")
     internal func post(notification: NotificationEnum, object: Any? = nil) {
         let userInfo = [NotificationCenter.notificationKey: notification]
         post(name: notification.name, object: object, userInfo: userInfo)

--- a/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
@@ -2,7 +2,7 @@ import UIKit
 import DrawerKit
 
 class PresentedViewController: UIViewController {
-    private var notificationToken: NotificationToken!
+    private var notificationTokens: [NotificationToken] = []
 
     @IBOutlet weak var presentedView: PresentedView!
     @IBAction func dismissButtonTapped() {
@@ -11,16 +11,26 @@ class PresentedViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.notificationToken = NotificationCenter.default
-            .addObserver(name: DrawerNotification.drawerExteriorTappedNotification) {
-            (notification: DrawerNotification, object: Any?) in
-            switch notification {
-            case .drawerExteriorTapped:
-                print("drawerExteriorTapped")
-            default:
-                break
-            }
-        }
+
+        let notificationTokens = [
+            NotificationCenter.default
+                .addObserver(DrawerNotifications.TransitionWillStart.self) { notification in
+                    print("transitionWillStart, isPresenting = \(notification.info.isPresenting)")
+                },
+            NotificationCenter.default
+                .addObserver(DrawerNotifications.TransitionDidFinish.self) { notification in
+                    print("transitionDidFinish, isPresenting = \(notification.info.isPresenting)")
+                },
+            NotificationCenter.default
+                .addObserver(DrawerNotifications.DrawerInteriorTapped.self) { notification in
+                    print("drawerInteriorTapped")
+                },
+            NotificationCenter.default
+                .addObserver(DrawerNotifications.DrawerExteriorTapped.self) { notification in
+                    print("drawerExteriorTapped")
+                }
+        ]
+        self.notificationTokens.append(contentsOf: notificationTokens)
     }
 
     @IBAction func unwindFromModal(with segue: UIStoryboardSegue) {}


### PR DESCRIPTION
Deprecated `enum DrawerNotification` in favor of new `protocol DrawerNotificationInfo` with struct-based conforming types.

**Note: This is non-breaking changes**

### Why?

Current `enum DrawerNotification` is a bad practice of using sum type due to the following reasons:

- Pattern matching is useless
- Breaking change for every addition of notification cases
