### PR TITLE
Add `DrawerBackgroundConfiguration` to customize arbitrary background

### DIFF
--- a/DrawerKit/DrawerKit.xcodeproj/project.pbxproj
+++ b/DrawerKit/DrawerKit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1F24F6C0225A5D11001DBE9C /* DrawerBackgroundConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F24F6BF225A5D11001DBE9C /* DrawerBackgroundConfiguration.swift */; };
 		654604CE207BD4BC00B72395 /* DrawerPresentationControlling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654604CD207BD4BC00B72395 /* DrawerPresentationControlling.swift */; };
 		9A158BC22076C92200FD4113 /* PresentationController+PullToDismiss.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A158BC12076C92200FD4113 /* PresentationController+PullToDismiss.swift */; };
 		B5D4058C21811B77000B3349 /* PresentationContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D4058B21811B77000B3349 /* PresentationContainerView.swift */; };
@@ -43,6 +44,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1F24F6BF225A5D11001DBE9C /* DrawerBackgroundConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DrawerBackgroundConfiguration.swift; sourceTree = "<group>"; };
 		654604CD207BD4BC00B72395 /* DrawerPresentationControlling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerPresentationControlling.swift; sourceTree = "<group>"; };
 		9A158BC12076C92200FD4113 /* PresentationController+PullToDismiss.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PresentationController+PullToDismiss.swift"; sourceTree = "<group>"; };
 		B5D4058B21811B77000B3349 /* PresentationContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentationContainerView.swift; sourceTree = "<group>"; };
@@ -143,6 +145,7 @@
 				CBB9A9761FA8DC04008253CB /* HandleViewConfiguration.swift */,
 				CB1B6E001FC8629B006C1F89 /* DrawerBorderConfiguration.swift */,
 				CB1B6DF21FC346CC006C1F89 /* DrawerShadowConfiguration.swift */,
+				1F24F6BF225A5D11001DBE9C /* DrawerBackgroundConfiguration.swift */,
 				CB5AF8011F9BDF29000B2DC9 /* DrawerAnimationActions.swift */,
 				CB5AF8031F9BE037000B2DC9 /* DrawerAnimationInfo.swift */,
 				CB5AF8051F9BE0E3000B2DC9 /* DrawerGeometry.swift */,
@@ -292,6 +295,7 @@
 				CB2CB7971F8E934500AA152D /* DrawerConfiguration.swift in Sources */,
 				CB3CAFBE1FB248B000AD28A1 /* DrawerNotifications.swift in Sources */,
 				CBFA36F21F9C4004006847BB /* GeometryEvaluator.swift in Sources */,
+				1F24F6C0225A5D11001DBE9C /* DrawerBackgroundConfiguration.swift in Sources */,
 				CB6F86B41F9C036D000FA37A /* PresentationController+Utilities.swift in Sources */,
 				CB1B6E011FC8629B006C1F89 /* DrawerBorderConfiguration.swift in Sources */,
 				CB5AF8141F9BEA91000B2DC9 /* DrawerAnimationInfo+Geometry.swift in Sources */,

--- a/DrawerKit/DrawerKit/Internal API/AnimationController.swift
+++ b/DrawerKit/DrawerKit/Internal API/AnimationController.swift
@@ -87,6 +87,10 @@ extension AnimationController: UIViewControllerAnimatedTransitioning {
             AnimationSupport.clientAnimateAlong(presentingDrawerAnimationActions: presentingAnimationActions,
                                                 presentedDrawerAnimationActions: presentedAnimationActions,
                                                 info)
+
+            if let presentationController = presentedVC.presentationController as? PresentationController {
+                presentationController.currentDrawerY = finalFrame.origin.y
+            }
         }
 
         animator.addCompletion { endingPosition in

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Properties.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Properties.swift
@@ -80,6 +80,13 @@ extension PresentationController {
             let drawerFullY = configuration.fullExpansionBehaviour.drawerFullY
             let posY = min(max(newValue, drawerFullY), containerViewHeight)
             presentedView?.frame.origin.y = posY
+
+            if let backgroundView = backgroundView,
+                let handle = configuration.drawerBackgroundConfiguration?.handle {
+
+                let context = DrawerBackgroundConfiguration.HandleContext(currentY: posY, containerHeight: containerViewHeight)
+                handle(backgroundView, context)
+            }
         }
     }
 

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Setup.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Setup.swift
@@ -26,6 +26,25 @@ extension PresentationController {
 }
 
 extension PresentationController {
+    func setupBackgroundView() {
+        guard let config = self.configuration.drawerBackgroundConfiguration else { return }
+        guard let presentationContainerView = self.presentationContainerView else { return }
+
+        let backgroundView = config.make()
+        backgroundView.frame = presentationContainerView.bounds
+        backgroundView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+
+        presentationContainerView.insertSubview(backgroundView, at: 0)
+
+        self.backgroundView = backgroundView
+    }
+
+    func removeBackgroundView() {
+        backgroundView?.removeFromSuperview()
+    }
+}
+
+extension PresentationController {
     func setupDrawerFullExpansionTapRecogniser() {
         guard drawerFullExpansionTapGR == nil else { return }
         let isFullyPresentable = isFullyPresentableByDrawerTaps

--- a/DrawerKit/DrawerKit/Internal API/PresentationController.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController.swift
@@ -7,6 +7,8 @@ final class PresentationController: UIPresentationController {
 
     var presentationContainerView: PresentationContainerView!
 
+    var backgroundView: UIView?
+
     let presentingDrawerAnimationActions: DrawerAnimationActions
     let presentedDrawerAnimationActions: DrawerAnimationActions
 
@@ -116,6 +118,8 @@ extension PresentationController {
     override func presentationTransitionWillBegin() {
         setupPresentationContainerView()
 
+        setupBackgroundView()
+
         // NOTE: `targetDrawerState.didSet` is not invoked within the
         //        initializer.
         gestureAvailabilityConditionsDidChange()
@@ -147,6 +151,7 @@ extension PresentationController {
 
     override func dismissalTransitionDidEnd(_ completed: Bool) {
         removePresentationContainerView()
+        removeBackgroundView()
         removeDrawerFullExpansionTapRecogniser()
         removeDrawerDismissalTapRecogniser()
         removeDrawerDragRecogniser()

--- a/DrawerKit/DrawerKit/Public API/Structs/DrawerBackgroundConfiguration.swift
+++ b/DrawerKit/DrawerKit/Public API/Structs/DrawerBackgroundConfiguration.swift
@@ -1,0 +1,39 @@
+import UIKit
+
+/// Configuration options for the drawer's background.
+public struct DrawerBackgroundConfiguration {
+    /// BackgroundView builder.
+    internal let make: () -> UIView
+
+    /// BackgroundView handler.
+    internal let handle: (UIView, HandleContext) -> Void
+
+    public init<BackgroundView>(make: @escaping () -> BackgroundView,
+                                handle: @escaping (BackgroundView, HandleContext) -> Void)
+        where BackgroundView: UIView {
+        self.make = make
+        self.handle = { handle($0 as! BackgroundView, $1) }
+    }
+
+    // MARK: - HandleContext
+
+    public struct HandleContext {
+        public let currentY: CGFloat
+        public let containerHeight: CGFloat
+    }
+}
+
+extension DrawerBackgroundConfiguration {
+    /// Dark background
+    public static let dark: DrawerBackgroundConfiguration = .init(
+        make: { () -> UIView in
+            let backgroundView = UIView()
+            backgroundView.backgroundColor = UIColor.black.withAlphaComponent(0.8)
+            backgroundView.alpha = 0
+            return backgroundView
+        },
+        handle: {
+            $0.alpha = (1 - $1.currentY / $1.containerHeight)
+        }
+    )
+}

--- a/DrawerKit/DrawerKit/Public API/Structs/DrawerConfiguration.swift
+++ b/DrawerKit/DrawerKit/Public API/Structs/DrawerConfiguration.swift
@@ -175,6 +175,8 @@ public struct DrawerConfiguration {
     /// by how these options are configured.
     public var passthroughTouchesInStates: PassthroughOptions
 
+    public var drawerBackgroundConfiguration: DrawerBackgroundConfiguration?
+
     public init(initialState: DrawerState? = nil,
                 totalDurationInSeconds: TimeInterval = 0.4,
                 durationIsProportionalToDistanceTraveled: Bool = false,
@@ -195,6 +197,7 @@ public struct DrawerConfiguration {
                 handleViewConfiguration: HandleViewConfiguration? = HandleViewConfiguration(),
                 drawerBorderConfiguration: DrawerBorderConfiguration? = nil,
                 drawerShadowConfiguration: DrawerShadowConfiguration? = nil,
+                drawerBackgroundConfiguration: DrawerBackgroundConfiguration? = nil,
                 passthroughTouchesInStates: PassthroughOptions = [.collapsed, .partiallyExpanded]) {
         self.initialState = initialState
         self.totalDurationInSeconds = (totalDurationInSeconds > 0 ? totalDurationInSeconds : 0.4)
@@ -223,6 +226,7 @@ public struct DrawerConfiguration {
         self.handleViewConfiguration = handleViewConfiguration
         self.drawerBorderConfiguration = drawerBorderConfiguration
         self.drawerShadowConfiguration = drawerShadowConfiguration
+        self.drawerBackgroundConfiguration = drawerBackgroundConfiguration
         self.passthroughTouchesInStates = passthroughTouchesInStates
     }
 }

--- a/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresenterViewController.swift
@@ -70,6 +70,8 @@ private extension PresenterViewController {
                                                                   shadowColor: .red)
         configuration.drawerShadowConfiguration = drawerShadowConfiguration // default is nil
 
+        configuration.drawerBackgroundConfiguration = .dark
+
         drawerDisplayController = DrawerDisplayController(presentingViewController: self,
                                                           presentedViewController: vc,
                                                           configuration: configuration,


### PR DESCRIPTION
This PR adds customizability of background view via `DrawerBackgroundConfiguration`.
Currently supporting `DrawerBackgroundConfiguration.dark` as a built-in style, and can be tested from Demo app.

Also, this PR will supersede #63 by importing 3rd party dynamic blur view library e.g. https://github.com/efremidze/VisualEffectView and add the following configuration manually:

```swift
extension DrawerBackgroundConfiguration {
    public static func visualEffect(style: UIBlurEffectStyle, blurRadius: CGFloat) -> DrawerBackgroundConfiguration {
        return DrawerBackgroundConfiguration(
            make: { () -> VisualEffectView in
                let effect = UIBlurEffect(style: style)
                let blurView = VisualEffectView(effect: effect)
                return blurView
            },
            handle: {
                $0.blurRadius = blurRadius * (1 - $1.currentY / $1.containerHeight)
            }
        )
    }
}
```
