### PR TITLE
allow dynamic full expansion behaviour

### DIFF
--- a/DrawerKit/DrawerKit/Internal API/AnimationController.swift
+++ b/DrawerKit/DrawerKit/Internal API/AnimationController.swift
@@ -47,6 +47,9 @@ extension AnimationController: UIViewControllerAnimatedTransitioning {
                                                      presentingVC: presentingVC,
                                                      presentedVC: presentedVC)
 
+        let drawerFullY = (presentedVC as? DrawerPresentable)?.fullExpansionBehaviour?.drawerFullY
+            ?? configuration.fullExpansionBehaviour.drawerFullY
+
         let drawerPartialH = (presentedVC as? DrawerPresentable)?.heightOfPartiallyExpandedDrawer ?? 0
         let partialH = GeometryEvaluator.drawerPartialH(drawerPartialHeight: drawerPartialH,
                                                         containerViewHeight: containerViewH)
@@ -55,17 +58,23 @@ extension AnimationController: UIViewControllerAnimatedTransitioning {
         let collapsedH = GeometryEvaluator.drawerPartialH(drawerPartialHeight: drawerCollapsedH,
                                                           containerViewHeight: containerViewH)
 
-        let startDrawerState = GeometryEvaluator.drawerState(for: initialFrame.origin.y,
-                                                             drawerCollapsedHeight: collapsedH,
-                                                             drawerPartialHeight: partialH,
-                                                             containerViewHeight: containerViewH,
-                                                             configuration: configuration)
+        let startDrawerState = GeometryEvaluator.drawerState(
+            for: initialFrame.origin.y,
+            drawerFullY: drawerFullY,
+            drawerCollapsedHeight: collapsedH,
+            drawerPartialHeight: partialH,
+            containerViewHeight: containerViewH,
+            configuration: configuration
+        )
 
-        let targetDrawerState = GeometryEvaluator.drawerState(for: finalFrame.origin.y,
-                                                              drawerCollapsedHeight: collapsedH,
-                                                              drawerPartialHeight: partialH,
-                                                              containerViewHeight: containerViewH,
-                                                              configuration: configuration)
+        let targetDrawerState = GeometryEvaluator.drawerState(
+            for: finalFrame.origin.y,
+            drawerFullY: drawerFullY,
+            drawerCollapsedHeight: collapsedH,
+            drawerPartialHeight: partialH,
+            containerViewHeight: containerViewH,
+            configuration: configuration
+        )
 
         let info = AnimationSupport.makeInfo(startDrawerState: startDrawerState,
                                              targetDrawerState: targetDrawerState,

--- a/DrawerKit/DrawerKit/Internal API/GeometryEvaluator.swift
+++ b/DrawerKit/DrawerKit/Internal API/GeometryEvaluator.swift
@@ -25,10 +25,12 @@ struct GeometryEvaluator {
         return containerViewHeight - collapsedH
     }
 
-    static func upperMarkY(drawerPartialHeight: CGFloat,
-                           containerViewHeight: CGFloat,
-                           configuration: DrawerConfiguration) -> CGFloat {
-        let drawerFullY = configuration.fullExpansionBehaviour.drawerFullY
+    static func upperMarkY(
+        drawerFullY: CGFloat,
+        drawerPartialHeight: CGFloat,
+        containerViewHeight: CGFloat,
+        configuration: DrawerConfiguration
+    ) -> CGFloat {
         let partialY = drawerPartialY(drawerPartialHeight: drawerPartialHeight,
                                       containerViewHeight: containerViewHeight)
         return max(partialY - configuration.upperMarkGap, drawerFullY)
@@ -43,11 +45,12 @@ struct GeometryEvaluator {
     }
 
     static func clamped(_ positionY: CGFloat,
+                        drawerFullY: CGFloat,
                         drawerPartialHeight: CGFloat,
                         containerViewHeight: CGFloat,
                         configuration: DrawerConfiguration) -> CGFloat {
-        let drawerFullY = configuration.fullExpansionBehaviour.drawerFullY
-        let upperY = upperMarkY(drawerPartialHeight: drawerPartialHeight,
+        let upperY = upperMarkY(drawerFullY: drawerFullY,
+                                drawerPartialHeight: drawerPartialHeight,
                                 containerViewHeight: containerViewHeight,
                                 configuration: configuration)
         if smallerThanOrEqual(positionY, upperY) {
@@ -73,12 +76,12 @@ struct GeometryEvaluator {
 
 extension GeometryEvaluator {
     static func drawerState(for positionY: CGFloat,
+                            drawerFullY: CGFloat,
                             drawerCollapsedHeight: CGFloat,
                             drawerPartialHeight: CGFloat,
                             containerViewHeight: CGFloat,
                             configuration: DrawerConfiguration,
                             clampToNearest: Bool = false) -> DrawerState {
-        let drawerFullY = configuration.fullExpansionBehaviour.drawerFullY
         if smallerThanOrEqual(positionY, drawerFullY) { return .fullyExpanded }
         if greaterThanOrEqual(positionY, containerViewHeight) { return .dismissed }
 
@@ -92,10 +95,12 @@ extension GeometryEvaluator {
 
         if clampToNearest {
             let posY = clamped(positionY,
+                               drawerFullY: drawerFullY,
                                drawerPartialHeight: drawerPartialHeight,
                                containerViewHeight: containerViewHeight,
                                configuration: configuration)
             return drawerState(for: posY,
+                               drawerFullY: drawerFullY,
                                drawerCollapsedHeight: drawerCollapsedHeight,
                                drawerPartialHeight: drawerPartialHeight,
                                containerViewHeight: containerViewHeight,
@@ -128,6 +133,7 @@ extension GeometryEvaluator {
 
     static func nextStateFrom(currentState: DrawerState,
                               speedY: CGFloat,
+                              drawerFullY: CGFloat,
                               drawerCollapsedHeight: CGFloat,
                               drawerPartialHeight: CGFloat,
                               containerViewHeight: CGFloat,
@@ -141,15 +147,14 @@ extension GeometryEvaluator {
         let isMovingUpQuickly = isMovingUp && isMovingQuickly
         let isMovingDownQuickly = isMovingDown && isMovingQuickly
 
-        let drawerFullY = configuration.fullExpansionBehaviour.drawerFullY
-
         let positionY = drawerPositionY(for: currentState,
                                         drawerCollapsedHeight: drawerCollapsedHeight,
                                         drawerPartialHeight: drawerPartialHeight,
                                         containerViewHeight: containerViewHeight,
                                         drawerFullY: drawerFullY)
 
-        let upperY = upperMarkY(drawerPartialHeight: drawerPartialHeight,
+        let upperY = upperMarkY(drawerFullY: drawerFullY,
+                                drawerPartialHeight: drawerPartialHeight,
                                 containerViewHeight: containerViewHeight,
                                 configuration: configuration)
 

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Animation.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Animation.swift
@@ -91,11 +91,14 @@ extension PresentationController {
             }
 
             if endingPosition != .end {
-                self.targetDrawerState = GeometryEvaluator.drawerState(for: self.currentDrawerY,
-                                                                       drawerCollapsedHeight: self.drawerCollapsedHeight,
-                                                                       drawerPartialHeight: self.drawerPartialY,
-                                                                       containerViewHeight: self.containerViewHeight,
-                                                                       configuration: self.configuration)
+                self.targetDrawerState = GeometryEvaluator.drawerState(
+                    for: self.currentDrawerY,
+                    drawerFullY: self.drawerFullY,
+                    drawerCollapsedHeight: self.drawerCollapsedHeight,
+                    drawerPartialHeight: self.drawerPartialY,
+                    containerViewHeight: self.containerViewHeight,
+                    configuration: self.configuration
+                )
             }
 
             AnimationSupport.clientCleanupViews(presentingDrawerAnimationActions: presentingAnimationActions,
@@ -110,7 +113,6 @@ extension PresentationController {
     }
 
     func addCornerRadiusAnimationEnding(at endingState: DrawerState) {
-        let drawerFullY = configuration.fullExpansionBehaviour.drawerFullY
         guard maximumCornerRadius != 0
             && drawerPartialY != drawerFullY
             && endingState != currentDrawerState
@@ -162,7 +164,6 @@ extension PresentationController {
 
     private func positionsY(startingState: DrawerState,
                             endingState: DrawerState) -> (starting: CGFloat, ending: CGFloat) {
-        let drawerFullY = configuration.fullExpansionBehaviour.drawerFullY
         let startingPositionY =
             GeometryEvaluator.drawerPositionY(for: startingState,
                                               drawerCollapsedHeight: drawerCollapsedHeight,

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Gestures.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Gestures.swift
@@ -32,12 +32,15 @@ extension PresentationController {
 
         case .ended:
             let drawerSpeedY = panGesture.velocity(in: view).y / containerViewHeight
-            let endingState = GeometryEvaluator.nextStateFrom(currentState: currentDrawerState,
-                                                              speedY: drawerSpeedY,
-                                                              drawerCollapsedHeight: drawerCollapsedHeight,
-                                                              drawerPartialHeight: drawerPartialHeight,
-                                                              containerViewHeight: containerViewHeight,
-                                                              configuration: configuration)
+            let endingState = GeometryEvaluator.nextStateFrom(
+                currentState: currentDrawerState,
+                speedY: drawerSpeedY,
+                drawerFullY: drawerFullY,
+                drawerCollapsedHeight: drawerCollapsedHeight,
+                drawerPartialHeight: drawerPartialHeight,
+                containerViewHeight: containerViewHeight,
+                configuration: configuration
+            )
             animateTransition(to: endingState)
 
         case .cancelled:

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+Properties.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+Properties.swift
@@ -13,6 +13,11 @@ extension PresentationController {
         return containerViewSize.height
     }
 
+    var drawerFullY: CGFloat {
+        return (presentedViewController as? DrawerPresentable)?.fullExpansionBehaviour?.drawerFullY
+            ?? configuration.fullExpansionBehaviour.drawerFullY
+    }
+
     var drawerPartialHeight: CGFloat {
         guard let presentedVC = presentedViewController as? DrawerPresentable else { return 0 }
         let drawerPartialH = presentedVC.heightOfPartiallyExpandedDrawer
@@ -38,7 +43,8 @@ extension PresentationController {
     }
 
     var upperMarkY: CGFloat {
-        return GeometryEvaluator.upperMarkY(drawerPartialHeight: drawerPartialHeight,
+        return GeometryEvaluator.upperMarkY(drawerFullY: drawerFullY,
+                                            drawerPartialHeight: drawerPartialHeight,
                                             containerViewHeight: containerViewHeight,
                                             configuration: configuration)
     }
@@ -52,6 +58,7 @@ extension PresentationController {
     var currentDrawerState: DrawerState {
         get {
             return GeometryEvaluator.drawerState(for: currentDrawerY,
+                                                 drawerFullY: drawerFullY,
                                                  drawerCollapsedHeight: drawerCollapsedHeight,
                                                  drawerPartialHeight: drawerPartialHeight,
                                                  containerViewHeight: containerViewHeight,
@@ -59,7 +66,6 @@ extension PresentationController {
         }
 
         set {
-            let drawerFullY = configuration.fullExpansionBehaviour.drawerFullY
             currentDrawerY =
                 GeometryEvaluator.drawerPositionY(for: newValue,
                                                   drawerCollapsedHeight: drawerCollapsedHeight,
@@ -71,13 +77,11 @@ extension PresentationController {
 
     var currentDrawerY: CGFloat {
         get {
-            let drawerFullY = configuration.fullExpansionBehaviour.drawerFullY
             let posY = presentedView?.frame.origin.y ?? drawerFullY
             return min(max(posY, drawerFullY), containerViewHeight)
         }
 
         set {
-            let drawerFullY = configuration.fullExpansionBehaviour.drawerFullY
             let posY = min(max(newValue, drawerFullY), containerViewHeight)
             presentedView?.frame.origin.y = posY
         }
@@ -113,16 +117,15 @@ extension PresentationController {
         case .maximumAtPartialY:
             return maximumCornerRadius * triangularValue(at: state)
         case .alwaysShowBelowStatusBar:
-            let drawerFullY = configuration.fullExpansionBehaviour.drawerFullY
-            let positionY =
-                GeometryEvaluator.drawerPositionY(for: state,
-                                                  drawerCollapsedHeight: drawerCollapsedHeight,
-                                                  drawerPartialHeight: drawerPartialHeight,
-                                                  containerViewHeight: containerViewHeight,
-                                                  drawerFullY: drawerFullY)
+            let positionY = GeometryEvaluator.drawerPositionY(
+                for: state,
+                drawerCollapsedHeight: drawerCollapsedHeight,
+                drawerPartialHeight: drawerPartialHeight,
+                containerViewHeight: containerViewHeight,
+                drawerFullY: drawerFullY
+            )
 
             return maximumCornerRadius * min(positionY, DrawerGeometry.statusBarHeight) / DrawerGeometry.statusBarHeight
-
         }
     }
 
@@ -131,7 +134,6 @@ extension PresentationController {
     }
 
     private func triangularValue(at state: DrawerState) -> CGFloat {
-        let drawerFullY = configuration.fullExpansionBehaviour.drawerFullY
         guard drawerPartialY != drawerFullY
             && drawerPartialY != containerViewHeight
             && drawerFullY != containerViewHeight

--- a/DrawerKit/DrawerKit/Internal API/PresentationController+PullToDismiss.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController+PullToDismiss.swift
@@ -103,12 +103,15 @@ final class PullToDismissManager: NSObject, UIScrollViewDelegate {
         }
 
         let drawerSpeedY = -velocity.y / presentationController.containerViewHeight
-        let endingState = GeometryEvaluator.nextStateFrom(currentState: presentationController.currentDrawerState,
-                                                          speedY: drawerSpeedY,
-                                                          drawerCollapsedHeight: presentationController.drawerCollapsedHeight,
-                                                          drawerPartialHeight: presentationController.drawerPartialHeight,
-                                                          containerViewHeight: presentationController.containerViewHeight,
-                                                          configuration: presentationController.configuration)
+        let endingState = GeometryEvaluator.nextStateFrom(
+            currentState: presentationController.currentDrawerState,
+            speedY: drawerSpeedY,
+            drawerFullY: presentationController.drawerFullY,
+            drawerCollapsedHeight: presentationController.drawerCollapsedHeight,
+            drawerPartialHeight: presentationController.drawerPartialHeight,
+            containerViewHeight: presentationController.containerViewHeight,
+            configuration: presentationController.configuration
+        )
 
         presentationController.animateTransition(
             to: endingState,

--- a/DrawerKit/DrawerKit/Internal API/PresentationController.swift
+++ b/DrawerKit/DrawerKit/Internal API/PresentationController.swift
@@ -104,7 +104,6 @@ extension PresentationController {
         var frame: CGRect = .zero
         frame.size = size(forChildContentContainer: presentedViewController,
                           withParentContainerSize: containerViewSize)
-        let drawerFullY = configuration.fullExpansionBehaviour.drawerFullY
         frame.origin.y = GeometryEvaluator.drawerPositionY(for: targetDrawerState,
                                                            drawerCollapsedHeight: drawerCollapsedHeight,
                                                            drawerPartialHeight: drawerPartialHeight,

--- a/DrawerKit/DrawerKit/Public API/Protocols/DrawerPresentable.swift
+++ b/DrawerKit/DrawerKit/Public API/Protocols/DrawerPresentable.swift
@@ -11,8 +11,15 @@ public protocol DrawerPresentable: class {
     /// collapsed state. If negative, its value is clamped to zero.
     /// Default implementation returns 0.
     var heightOfCollapsedDrawer: CGFloat { get }
+
+    /// Whether the drawer expands to cover the entire screen, the entire screen minus
+    /// the status bar, or the entire screen minus a custom gap. If this property
+    /// returns `nil` then the value of `fullExpansionBehaviour` in the `DrawerConfiguration`
+    /// will be used instead. The default is `nil`.
+    var fullExpansionBehaviour: DrawerConfiguration.FullExpansionBehaviour? { get }
 }
 
 public extension DrawerPresentable {
     var heightOfCollapsedDrawer: CGFloat { return 0 }
+    var fullExpansionBehaviour: DrawerConfiguration.FullExpansionBehaviour? { return nil }
 }

--- a/DrawerKit/DrawerKit/Public API/Structs/DrawerConfiguration.swift
+++ b/DrawerKit/DrawerKit/Public API/Structs/DrawerConfiguration.swift
@@ -82,7 +82,9 @@ public struct DrawerConfiguration {
 
     /// Whether the drawer expands to cover the entire screen, the entire screen minus
     /// the status bar, or the entire screen minus a custom gap. The default is to cover
-    /// the full screen.
+    /// the full screen. If presented view controller conforms to the DrawerPresentable
+    /// the value that it returns from `fullExpansionBehaviour` will be used instead,
+    /// unless it is `nil`.
     public var fullExpansionBehaviour: FullExpansionBehaviour
 
     /// When `true`, the drawer is presented first in its partially expanded state.

--- a/DrawerKitDemo/DrawerKitDemo/PresentedNavigationController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresentedNavigationController.swift
@@ -24,6 +24,10 @@ extension PresentedNavigationController: DrawerPresentable {
     var heightOfPartiallyExpandedDrawer: CGFloat {
         return (topViewController as? DrawerPresentable)?.heightOfPartiallyExpandedDrawer ?? 0.0
     }
+
+    var fullExpansionBehaviour: DrawerConfiguration.FullExpansionBehaviour? {
+        return (topViewController as? DrawerPresentable)?.fullExpansionBehaviour
+    }
 }
 
 extension PresentedNavigationController: UINavigationControllerDelegate {

--- a/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
@@ -35,7 +35,7 @@ extension PresentedViewController: DrawerPresentable {
 //    }
 
 //    var fullExpansionBehaviour: DrawerConfiguration.FullExpansionBehaviour? {
-//        return .leavesCustomGap(gap: view.bounds.size.height - heightOfPartiallyExpandedDrawer)
+//        return .leavesCustomGap(gap: 100)
 //    }
 
     var heightOfPartiallyExpandedDrawer: CGFloat {

--- a/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
+++ b/DrawerKitDemo/DrawerKitDemo/PresentedViewController.swift
@@ -34,6 +34,10 @@ extension PresentedViewController: DrawerPresentable {
 //        return 100
 //    }
 
+//    var fullExpansionBehaviour: DrawerConfiguration.FullExpansionBehaviour? {
+//        return .leavesCustomGap(gap: view.bounds.size.height - heightOfPartiallyExpandedDrawer)
+//    }
+
     var heightOfPartiallyExpandedDrawer: CGFloat {
         guard let view = self.view as? PresentedView else { return 0 }
 


### PR DESCRIPTION
This PRs adds, in addition to static configuration, ability to change the full expansion behaviour dynamically via `DrawerPresentable` protocol, similarly to partially expanded behaviour