### PR TITLE
Make `DrawerConfiguration.fullExpansionBehaviour.drawerFullY` public

### DIFF
--- a/DrawerKit/DrawerKit/Public API/Structs/DrawerConfiguration.swift
+++ b/DrawerKit/DrawerKit/Public API/Structs/DrawerConfiguration.swift
@@ -8,7 +8,7 @@ public struct DrawerConfiguration {
         case doesNotCoverStatusBar
         case leavesCustomGap(gap: CGFloat)
 
-        var drawerFullY: CGFloat {
+        public var drawerFullY: CGFloat {
             switch self {
             case .coversFullScreen:
                 return 0


### PR DESCRIPTION
This can be useful to know, for instance when setting the content insets for scrollable content.